### PR TITLE
feat: add PR auto-assignment workflow and configuration

### DIFF
--- a/.github/pr-assigner-config.yml
+++ b/.github/pr-assigner-config.yml
@@ -1,0 +1,3 @@
+assignees:
+  - dmitry618
+count: 1

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -1,0 +1,15 @@
+name: PR Auto-Assignment
+run-name: "Assigning reviewers for PR #${{ github.event.pull_request.number }}"
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr-auto-assign:
+    uses: netcracker/qubership-workflow-hub/.github/workflows/re-pr-assigner.yml@main


### PR DESCRIPTION
Introduce a workflow for automatically assigning reviewers to pull requests on the main branch. This configuration streamlines the review process by designating specific assignees.
<!-- start messages -->
### Commit messages:
[nookyo](https://github.com/Netcracker/qubership-nifi/commit/bef991bd09f6106234200f988f305cbe8c906700) feat: add PR auto-assignment workflow and configuration
<!-- end messages -->
