### PR TITLE
fix(ci): add missing permissions to cdxgen and maven-release workflows

### DIFF
--- a/.github/workflows/cdxgen.yaml
+++ b/.github/workflows/cdxgen.yaml
@@ -7,11 +7,13 @@
 
 name: 'CDXGen'
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   push:
     branches:
       - 'main'
 
+permissions:
+  contents: read
 jobs:
   cdxgen:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -42,6 +42,9 @@ on:
         default: false
         description: 'Dry run'
 
+permissions:
+  contents: write
+  packages: write
 jobs:
   check-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add missing permissions to cdxgen and maven-release workflows.