### PR TITLE
fix: fix remote debugging for Java9+

### DIFF
--- a/nifi-config/bootstrap.conf
+++ b/nifi-config/bootstrap.conf
@@ -33,7 +33,7 @@ java.arg.2=-Xms512m
 java.arg.3=-Xmx512m
 
 # Enable Remote Debugging
-#java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
+#java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
 
 # allowRestrictedHeaders is required for Cluster/Node communications to work properly
 java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true


### PR DESCRIPTION
Fixes remote debugging enabled via `NIFI_JVM_DEBUGGER` environment variable.
Previous version worked only up to Java 8, not on Java 21 currently used.