### PR TITLE
feat: mark influxdb-related components as deprecated

### DIFF
--- a/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/AbstractInfluxDbReportingTask.java
+++ b/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/AbstractInfluxDbReportingTask.java
@@ -40,6 +40,9 @@ import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.InfluxDBIOException;
 
+/**
+ * @deprecated Since qubership-nifi v.2.4.0. To be removed in 2.7.0.
+ */
 @Deprecated(since = "2.4.0", forRemoval = true)
 public abstract class AbstractInfluxDbReportingTask
         extends AbstractReportingTask {

--- a/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/CommonMetricsReportingTask.java
+++ b/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/CommonMetricsReportingTask.java
@@ -41,6 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @deprecated Since qubership-nifi v.2.4.0. To be removed in 2.7.0.
+ */
 @Tags({"reporting", "influxdb", "metrics"})
 @CapabilityDescription("Sends Nifi metrics to InfluxDB.")
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "15 sec")

--- a/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/ComponentMetricsReportingTask.java
+++ b/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/reporting/ComponentMetricsReportingTask.java
@@ -34,6 +34,9 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.reporting.ReportingContext;
 import org.apache.nifi.scheduling.SchedulingStrategy;
 
+/**
+ * @deprecated Since qubership-nifi v.2.4.0. To be removed in 2.7.0.
+ */
 @Tags({"reporting", "influxdb", "metrics"})
 @CapabilityDescription("Sends components (Processors, Connections) metrics to InfluxDB.")
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "15 sec")


### PR DESCRIPTION
InfluxDB reportings tasks are rarely used and based on outdated InfluxDB 1.x client libraries, so they are marked as deprecated in 2.4.0 to be removed in 2.7.0.

If required, new components must be developed from scratch supporting current InfluxDB 3.x and new java client libraries.