### PR TITLE
fix: fix profiles in qubership-nifi-docs-generator pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
+        <central-publishing.plugin.version>0.7.0</central-publishing.plugin.version>
         <nifi.version>2.7.2</nifi.version>
         <nifi.api.version>2.5.0</nifi.api.version>
         <nifi.nar.plugin.version>2.1.0</nifi.nar.plugin.version>
@@ -76,6 +77,8 @@
         <jgit.version>7.6.0.202603022253-r</jgit.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <commons-csv.version>1.8</commons-csv.version>
+
+        <skipUnitTests>false</skipUnitTests>
 
         <!-- Version for provided artifact -->
         <okhttp.version>5.1.0</okhttp.version>

--- a/qubership-consul/pom.xml
+++ b/qubership-consul/pom.xml
@@ -63,6 +63,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <central-publishing.plugin.version>0.7.0</central-publishing.plugin.version>
         <pmd.version>3.26.0</pmd.version>
         <jacoco.version>0.8.8</jacoco.version>
         <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
@@ -74,6 +75,7 @@
         <nifi.version>2.7.2</nifi.version>
         <spring-framework.version>6.2.15</spring-framework.version>
         <slf4j.version>2.0.17</slf4j.version>
+        <skipUnitTests>false</skipUnitTests>
     </properties>
 
     <profiles>

--- a/qubership-consul/qubership-consul-util/pom.xml
+++ b/qubership-consul/qubership-consul-util/pom.xml
@@ -123,7 +123,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-api-nar/pom.xml
+++ b/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-api-nar/pom.xml
@@ -57,7 +57,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-api/pom.xml
+++ b/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-api/pom.xml
@@ -53,7 +53,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-nar/pom.xml
+++ b/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis-nar/pom.xml
@@ -57,7 +57,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis/pom.xml
+++ b/qubership-nifi-bulk-redis-service/qubership-nifi-bulk-redis/pom.xml
@@ -167,7 +167,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-bundle-common/pom.xml
+++ b/qubership-nifi-bundle-common/pom.xml
@@ -221,7 +221,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-common/pom.xml
+++ b/qubership-nifi-common/pom.xml
@@ -112,7 +112,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/pom.xml
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>qubership-nifi-docs-generator</artifactId>
     <packaging>maven-plugin</packaging>
-    <name>qubership-nifi Documentation Generator Maven Plugin</name>
+    <name>${project.groupId}:${project.artifactId}</name>
     <description>Maven plugin that generates Markdown-based documentation
         from projects containing custom Apache NiFi components</description>
 
@@ -166,6 +166,36 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>central</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>github</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/qubership-services/qubership-service-api-nar/pom.xml
+++ b/qubership-services/qubership-service-api-nar/pom.xml
@@ -65,7 +65,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-services/qubership-service-api/pom.xml
+++ b/qubership-services/qubership-service-api/pom.xml
@@ -72,7 +72,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-services/qubership-service-nar/pom.xml
+++ b/qubership-services/qubership-service-nar/pom.xml
@@ -58,7 +58,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/qubership-services/qubership-service/pom.xml
+++ b/qubership-services/qubership-service/pom.xml
@@ -225,7 +225,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>${central-publishing.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Adds missing profiles in qubership-nifi-docs-generator pom.xml and moves central-publishing-maven-plugin version into property.