### PR TITLE
chore: refactor tools integration tests to decrease build time

### DIFF
--- a/qubership-nifi-tools/pom.xml
+++ b/qubership-nifi-tools/pom.xml
@@ -31,18 +31,26 @@
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Aggregator for NiFi tooling utilities</description>
 
+    <properties>
+        <!-- Skip ITs by default; enable with profile tools-integration-tests -->
+        <skipITs>true</skipITs>
+    </properties>
+
     <modules>
         <module>qubership-nifi-api-export-tool</module>
+        <module>qubership-nifi-api-export-tool-it</module>
         <module>qubership-nifi-docs-generator</module>
         <module>qubership-nifi-component-comparator-tool</module>
+        <module>qubership-nifi-docs-generator-it</module>
     </modules>
 
     <profiles>
         <profile>
             <id>tools-integration-tests</id>
-            <modules>
-                <module>qubership-nifi-docs-generator-it</module>
-            </modules>
+            <properties>
+                <!-- Enable ITs if running with profile -->
+                <skipITs>false</skipITs>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/qubership-nifi-tools/qubership-nifi-api-export-tool-it/pom.xml
+++ b/qubership-nifi-tools/qubership-nifi-api-export-tool-it/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.qubership.nifi</groupId>
+        <artifactId>qubership-nifi-tools</artifactId>
+        <version>2.4.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>qubership-nifi-api-export-tool-it</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Integration tests for the qubership-nifi-api-export-tool CLI tool</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.qubership.nifi</groupId>
+            <artifactId>qubership-nifi-api-export-tool</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/qubership-nifi-tools/qubership-nifi-api-export-tool-it/src/test/java/org/qubership/nifi/tools/export/ExportApiToolMainIT.java
+++ b/qubership-nifi-tools/qubership-nifi-api-export-tool-it/src/test/java/org/qubership/nifi/tools/export/ExportApiToolMainIT.java
@@ -18,25 +18,20 @@ package org.qubership.nifi.tools.export;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 /**
  * Integration tests that spin up a real NiFi container via TestContainers,
  * run the full Main pipeline, and verify the output file structure.
- *
  * These tests require Docker and take several minutes each.
  * Run selectively: mvn test -pl qubership-nifi-api-export-tool -Dgroups=docker
  */
-@Tag("docker")
-class MainIntegrationTest {
+class ExportApiToolMainIT {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -73,13 +68,13 @@ class MainIntegrationTest {
         File csDir = new File(outDir, "controllerService");
         File rtDir = new File(outDir, "reportingTask");
 
-        assertTrue(processorsDir.isDirectory(), "processors/ directory must exist");
-        assertTrue(csDir.isDirectory(), "controllerService/ directory must exist");
-        assertTrue(rtDir.isDirectory(), "reportingTask/ directory must exist");
+        Assertions.assertTrue(processorsDir.isDirectory(), "processors/ directory must exist");
+        Assertions.assertTrue(csDir.isDirectory(), "controllerService/ directory must exist");
+        Assertions.assertTrue(rtDir.isDirectory(), "reportingTask/ directory must exist");
 
-        assertTrue(processorsDir.list().length > 0, "processors/ must contain at least one file");
-        assertTrue(csDir.list().length > 0, "controllerService/ must contain at least one file");
-        assertTrue(rtDir.list().length > 0, "reportingTask/ must contain at least one file");
+        Assertions.assertTrue(processorsDir.list().length > 0, "processors/ must contain at least one file");
+        Assertions.assertTrue(csDir.list().length > 0, "controllerService/ must contain at least one file");
+        Assertions.assertTrue(rtDir.list().length > 0, "reportingTask/ must contain at least one file");
 
         assertValidJsonFile(processorsDir.listFiles()[0]);
         assertValidJsonFile(csDir.listFiles()[0]);
@@ -87,18 +82,18 @@ class MainIntegrationTest {
     }
 
     private void assertValidJsonFile(File jsonFile) throws Exception {
-        assertTrue(jsonFile.getName().endsWith(".json"),
+        Assertions.assertTrue(jsonFile.getName().endsWith(".json"),
                 "Output file must have .json extension: " + jsonFile.getName());
 
         JsonNode root = MAPPER.readTree(jsonFile);
 
-        assertTrue(root.has("type"), "JSON must have 'type' field in: " + jsonFile.getName());
-        assertFalse(root.get("type").asText().isEmpty(),
+        Assertions.assertTrue(root.has("type"), "JSON must have 'type' field in: " + jsonFile.getName());
+        Assertions.assertFalse(root.get("type").asText().isEmpty(),
                 "'type' must be a non-empty FQCN in: " + jsonFile.getName());
 
-        assertTrue(root.has("propertyDescriptors"),
+        Assertions.assertTrue(root.has("propertyDescriptors"),
                 "JSON must have 'propertyDescriptors' field in: " + jsonFile.getName());
-        assertTrue(root.get("propertyDescriptors").isObject(),
+        Assertions.assertTrue(root.get("propertyDescriptors").isObject(),
                 "'propertyDescriptors' must be a JSON object in: " + jsonFile.getName());
     }
 }


### PR DESCRIPTION
Refactors integration tests to:
1. to decrease build time for API export tool (~1.5 minutes)
2. to fix version updates during release process for IT modules under tools-integration-tests profile.