### PR TITLE
fix: remove duplicated dependency and add skipUnitTests property in quarkus consul app

### DIFF
--- a/qubership-nifi-quarkus-consul/pom.xml
+++ b/qubership-nifi-quarkus-consul/pom.xml
@@ -42,6 +42,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <skipUnitTests>false</skipUnitTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--libraries versions-->
         <quarkus.platform.version>3.27.2</quarkus.platform.version>
@@ -193,6 +194,8 @@
                 <version>${surefire-plugin.version}</version>
                 <configuration>
                     <argLine>-Duser.timezone=UTC</argLine>
+                    <!-- Custom property to skip unit tests -->
+                    <skipTests>${skipUnitTests}</skipTests>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/pom.xml
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/pom.xml
@@ -108,12 +108,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.qubership.nifi</groupId>
-            <artifactId>qubership-nifi-consul-common</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
* removes duplicated dependency on qubership-nifi-consul-common in qubership-nifi-quarkus-consul-util
* adds skipUnitTests property support in qubership-nifi-quarkus-consul
