### PR TITLE
fix: process only consul config sources in quarkus consul util

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ USER root
 #add jq:
 RUN apk add --no-cache \
     jq=1.8.1-r0 \
-    python3=3.12.12-r0
+    python3=3.12.13-r0
 
 ENV NIFI_BASE_DIR=/opt/nifi
 ENV NIFI_HOME=$NIFI_BASE_DIR/nifi-current

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/pom.xml
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/pom.xml
@@ -51,6 +51,24 @@
             <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>
 
+        <!-- Consul Config Source  -->
+        <dependency>
+            <groupId>com.netcracker.cloud.quarkus</groupId>
+            <artifactId>consul-config-source</artifactId>
+            <version>${consul-config-source.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.netcracker.cloud.quarkus</groupId>
+                    <artifactId>log-manager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.netcracker.cloud.quarkus</groupId>
+                    <artifactId>log-manager-deployment</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -89,24 +107,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jacoco</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <!-- Consul Config Source  -->
-        <dependency>
-            <groupId>com.netcracker.cloud.quarkus</groupId>
-            <artifactId>consul-config-source</artifactId>
-            <version>${consul-config-source.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.netcracker.cloud.quarkus</groupId>
-                    <artifactId>log-manager</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.netcracker.cloud.quarkus</groupId>
-                    <artifactId>log-manager-deployment</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
@@ -28,8 +28,8 @@ public class ConsulPropertiesProvider implements PropertiesProvider {
         for (ConfigSource configSource : config.getConfigSources()) {
             String configSourceName = configSource.getName();
             //config source name must start with ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME
-            if (configSourceName != null &&
-                    configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
+            if (configSourceName != null
+                    && configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
                 Set<String> allNames = configSource.getPropertyNames();
                 for (String name : allNames) {
                     if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.")) {

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
@@ -1,5 +1,6 @@
 package org.qubership.cloud.nifi.quarkus.config;
 
+import com.netcracker.cloud.consul.config.source.runtime.ConsulConfigSourceFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.Config;
@@ -25,10 +26,15 @@ public class ConsulPropertiesProvider implements PropertiesProvider {
 
         // Get all config sources from MicroProfile Config
         for (ConfigSource configSource : config.getConfigSources()) {
-            Set<String> allNames = configSource.getPropertyNames();
-            for (String name : allNames) {
-                if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.")) {
-                    allPropertyNames.add(name);
+            String configSourceName = configSource.getName();
+            //config source name must start with ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME
+            if (configSourceName != null
+                    && configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
+                Set<String> allNames = configSource.getPropertyNames();
+                for (String name : allNames) {
+                    if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.")) {
+                        allPropertyNames.add(name);
+                    }
                 }
             }
         }

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/quarkus/config/ConsulPropertiesProvider.java
@@ -28,8 +28,8 @@ public class ConsulPropertiesProvider implements PropertiesProvider {
         for (ConfigSource configSource : config.getConfigSources()) {
             String configSourceName = configSource.getName();
             //config source name must start with ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME
-            if (configSourceName != null
-                    && configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
+            if (configSourceName != null &&
+                    configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
                 Set<String> allNames = configSource.getPropertyNames();
                 for (String name : allNames) {
                     if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.")) {

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTest.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTest.java
@@ -2,6 +2,7 @@ package org.qubership.cloud.nifi.quarkus.config;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -13,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.consul.ConsulContainer;
 import org.testcontainers.containers.Container;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 @QuarkusTest
 @QuarkusTestResource(ConsulTestResource.class)
+@TestProfile(PropertiesManagerTestProfile.class)
 public class PropertiesManagerTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(PropertiesManagerTest.class);
@@ -110,6 +111,14 @@ public class PropertiesManagerTest {
             Assertions.assertEquals("10",
                     nifiProps.getProperty("nifi.cluster.flow.election.max.candidates"),
                     "Consul property without default should be loaded");
+            Assertions.assertFalse(nifiProps.containsKey("NIFI_HOME"),
+                    "Env variable NIFI_HOME should not be loaded");
+            Assertions.assertFalse(nifiProps.containsKey("nifi.home"),
+                    "Env variable nifi.home should not be loaded");
+            Assertions.assertFalse(nifiProps.containsKey("nifi.env.prop1"),
+                    "Env variable nifi.env.prop1 should not be loaded");
+            Assertions.assertFalse(nifiProps.containsKey("nifi.env.prop2"),
+                    "Env variable nifi.env.prop2 should not be loaded");
         } catch (IOException e) {
             Assertions.fail("Failed to read nifi.properties", e);
         }

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTestProfile.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTestProfile.java
@@ -1,0 +1,23 @@
+package org.qubership.cloud.nifi.quarkus.config;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class PropertiesManagerTestProfile
+        implements QuarkusTestProfile {
+
+    public PropertiesManagerTestProfile () {
+        //default constructor
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+            "NIFI_HOME", "./test-location",
+            "nifi.home", "./test-location2",
+            "nifi.env.prop1", "1",
+            "nifi.env.prop2", "1"
+        );
+    }
+}

--- a/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTestProfile.java
+++ b/qubership-nifi-quarkus-consul/qubership-nifi-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/quarkus/config/PropertiesManagerTestProfile.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public class PropertiesManagerTestProfile
         implements QuarkusTestProfile {
 
-    public PropertiesManagerTestProfile () {
+    public PropertiesManagerTestProfile() {
         //default constructor
     }
 


### PR DESCRIPTION
Adds missing filter for config sources to be processed in qubership-nifi-quarkus-consul-util. Only Consul-related config sources must be processed similar to Spring-based qubership-consul-util.