### PR TITLE
fix: QueryIdsAndFetchTableToJson is missing in user guide

### DIFF
--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -5,6 +5,7 @@
 #Exclude test resources from linter processing:
 FILTER_REGEX_EXCLUDE=^.+/test/resources/.*$
 GITLEAKS_LOG_LEVEL=warn
+MARKDOWN_CONFIG_FILE=.markdownlint.json
 VALIDATE_BASH_EXEC=false
 VALIDATE_BIOME_FORMAT=false
 VALIDATE_BIOME_LINT=false

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,6 +21,7 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 | BackupAttributes | migration-nifi-processors-open | Backups all FlowFile attributes by adding prefix to their names. |
 | PutGeneratedRecord | migration-nifi-processors-open | A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'. |
 | QueryDatabaseToCSV | migration-nifi-processors-open | Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output. |
+| QueryIdsAndFetchTableToJson | migration-nifi-processors-open |  |
 | PutSQLRecord | qubership-nifi-db-processors-nar | Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction. |
 | PostgreSQLBulkLoader | qubership-nifi-db-processors-nar | The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content. |
 
@@ -146,6 +147,24 @@ The processor allows to split query result into several FlowFiles and select CSV
 | Batch Size | batch-size | 0 |  | The maximum number of rows from the result set to be saved in a single FlowFile. If set to 0, then the whole result set is saved to a single FlowFile. |
 | Fetch Size | fetch-size | 10000 |  | The number of result rows to be fetched from the result set at a time.  This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
 | Write By Batch | write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
+
+### QueryIdsAndFetchTableToJson
+
+
+
+| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
+|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
+| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the source database. |
+| Ids Database Connection Pooling Service | Ids Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the mapping database. |
+| Prepared Statement Provider | prepared-statement-provider-service |  |  | The Controller Service that is used to create a prepared statement. |
+| Custom Query | custom-query |  |  | Custom query for Source Data Base. |
+| Ids Custom Query | ids-custom-query | ${mapping.db.query} |  | Custom request to get a list of id. |
+| Batch Size | batch-size | 1 |  | The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile. |
+| Ids Batch Size | ids-batch-size | 1 |  | The maximum number of rows in table from ids database from the result. |
+| Fetch Size | fetch-size | 1 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored. |
+| Ids Fetch Size | ids-fetch-size | 1 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
+| Write By Batch | write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
+| Ids Write By Batch | ids-write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
 
 ### PutSQLRecord
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 |BackupAttributes|migration-nifi-processors-open|Backups all FlowFile attributes by adding prefix to their names.|
 |PutGeneratedRecord|migration-nifi-processors-open|A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'.|
 |QueryDatabaseToCSV|migration-nifi-processors-open|Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output.|
-|QueryIdsAndFetchTableToJson|migration-nifi-processors-open||
+|QueryIdsAndFetchTableToJson|migration-nifi-processors-open|Fetches data from source DB into JSON using query (Custom Query) and ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then for each batch of ids, main query is executed to get data and transform it to JSON. Data iscollected until Batch Size is reached, then it is loaded into FlowFile. Data collection continues until all rows are processed.|
 |PutSQLRecord|qubership-nifi-db-processors-nar|Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction.|
 |PostgreSQLBulkLoader|qubership-nifi-db-processors-nar|The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content.|
 
@@ -150,21 +150,25 @@ The processor allows to split query result into several FlowFiles and select CSV
 
 ### QueryIdsAndFetchTableToJson
 
-
+Fetches data from source DB into JSON using query (Custom Query) and
+ ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then
+ for each batch of ids, main query is executed to get data and transform it to JSON. Data is
+collected until Batch Size is reached, then it is loaded into FlowFile.
+ Data collection continues until all rows are processed.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
 |Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the source database.|
-|Ids Database Connection Pooling Service|Ids Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the mapping database.|
+|IDs Database Connection Pooling Service|Ids Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the mapping database.|
 |Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
 |Custom Query|custom-query|||Custom query for Source Data Base.|
-|Ids Custom Query|ids-custom-query|\${mapping.db.query}||Custom request to get a list of id.|
+|IDs Custom Query|ids-custom-query|\${mapping.db.query}||Custom request to get a list of IDs.|
 |Batch Size|batch-size|1||The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile.|
-|Ids Batch Size|ids-batch-size|1||The maximum number of rows in table from ids database from the result.|
+|IDs Batch Size|ids-batch-size|1||The maximum number of rows in table from IDs database from the result.|
 |Fetch Size|fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored.|
-|Ids Fetch Size|ids-fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|IDs Fetch Size|ids-fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
 |Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
-|Ids Write By Batch|ids-write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|IDs Write By Batch|ids-write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### PutSQLRecord
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,16 +14,16 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 |Processor|NAR|Description|
 |---|---|---|
-|QueryDatabaseToJsonWithMerge|migration-nifi-processors-open|Executes custom query to fetch rows from table and merge them with the main JSON object which is in the content of incoming FlowFile.  The Path property supports JsonPath syntax to find source ID attributes in the main object.  The main and queried objects are merged by join key properties.You can specify where exactly to insert queried objects and by what key with path  to insert and key to insert properties.|
-|QueryDatabaseToJson|migration-nifi-processors-open|Fetches data from database table and transforms it to JSON.This processor gets incoming FlowFile and reads ID attributes using JSON Path. Found IDs are passedin select query as an array. Obtained result set will be written into output FlowFile.Expects that content of an incoming FlowFile is array of unique business entity identifiers in the JSON format.|
-|FetchTableToJson|migration-nifi-processors-open|Fetches data from DB table into JSON using either query (Custom Query) or table (Table) and  list of columns (Columns To Return). This processor works in batched mode: it collects FlowFiles until  batch size limit is reached and then processes batch. This processor can accept incoming connections;  the behavior of the processor is different whether incoming connections are provided: -If no incoming connection(s) are specified, the processor will generate SQL queries on the specified  processor schedule. -If incoming connection(s) are specified and no FlowFile is available to a processor task, no work will be performed. -If incoming connection(s) are specified and a FlowFile is available to a processor task, query  will be executed when processing the next FlowFile.|
-|ValidateJson|migration-nifi-processors-open|Validates the content of FlowFiles against the JSON schema. The FlowFiles that are successfully validated against the specified schema are routed to valid relationship without any changes. The FlowFiles that are not valid according to the schema are routed to invalid relationship. Array with validation errors is added to the content of FlowFile.|
-|BackupAttributes|migration-nifi-processors-open|Backups all FlowFile attributes by adding prefix to their names.|
-|PutGeneratedRecord|migration-nifi-processors-open|A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'.|
-|QueryDatabaseToCSV|migration-nifi-processors-open|Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output.|
-|QueryIdsAndFetchTableToJson|migration-nifi-processors-open|Fetches data from source DB into JSON using query (Custom Query) and ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then for each batch of ids, main query is executed to get data and transform it to JSON. Data iscollected until Batch Size is reached, then it is loaded into FlowFile. Data collection continues until all rows are processed.|
-|PutSQLRecord|qubership-nifi-db-processors-nar|Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction.|
-|PostgreSQLBulkLoader|qubership-nifi-db-processors-nar|The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content.|
+|`QueryDatabaseToJsonWithMerge`|migration-nifi-processors-open|Executes custom query to fetch rows from table and merge them with the main JSON object which is in the content of incoming FlowFile.  The Path property supports JsonPath syntax to find source ID attributes in the main object.  The main and queried objects are merged by join key properties.You can specify where exactly to insert queried objects and by what key with path  to insert and key to insert properties.|
+|`QueryDatabaseToJson`|migration-nifi-processors-open|Fetches data from database table and transforms it to JSON.This processor gets incoming FlowFile and reads ID attributes using JSON Path. Found IDs are passedin select query as an array. Obtained result set will be written into output FlowFile.Expects that content of an incoming FlowFile is array of unique business entity identifiers in the JSON format.|
+|`FetchTableToJson`|migration-nifi-processors-open|Fetches data from DB table into JSON using either query (Custom Query) or table (Table) and  list of columns (Columns To Return). This processor works in batched mode: it collects FlowFiles until  batch size limit is reached and then processes batch. This processor can accept incoming connections;  the behavior of the processor is different whether incoming connections are provided: -If no incoming connection(s) are specified, the processor will generate SQL queries on the specified  processor schedule. -If incoming connection(s) are specified and no FlowFile is available to a processor task, no work will be performed. -If incoming connection(s) are specified and a FlowFile is available to a processor task, query  will be executed when processing the next FlowFile.|
+|`ValidateJson`|migration-nifi-processors-open|Validates the content of FlowFiles against the JSON schema. The FlowFiles that are successfully validated against the specified schema are routed to valid relationship without any changes. The FlowFiles that are not valid according to the schema are routed to invalid relationship. Array with validation errors is added to the content of FlowFile.|
+|`BackupAttributes`|migration-nifi-processors-open|Backups all FlowFile attributes by adding prefix to their names.|
+|`PutGeneratedRecord`|migration-nifi-processors-open|A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'.|
+|`QueryDatabaseToCSV`|migration-nifi-processors-open|Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output.|
+|`QueryIdsAndFetchTableToJson`|migration-nifi-processors-open|Fetches data from source DB into JSON using query (Custom Query) and IDs obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then for each batch of IDs, main query is executed to get data and transform it to JSON. Data iscollected until Batch Size is reached, then it is loaded into FlowFile. Data collection continues until all rows are processed.|
+|`PutSQLRecord`|qubership-nifi-db-processors-nar|Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction.|
+|`PostgreSQLBulkLoader`|qubership-nifi-db-processors-nar|The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content.|
 
 ## Additional processors properties description
 
@@ -40,17 +40,17 @@ You can specify where exactly to insert queried objects and by what key with pat
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
-|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
-|Batch Size|internal-batch-size|100||The maximum number of rows from the result set to be saved in single FlowFile.|
-|Fetch Size|Fetch Size|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
-|Query|db-fetch-sql-query|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
-|Path|path|||A JsonPath expression that specifies path to source ID attribute inside the array in the incoming FlowFile.|
-|Join Key Parent With Child|join-key-parent-with-child|||The objects' key in the input JSON that uses to join with objects that will be queried|
-|Join Key Child With Parent|Join Key Child With Parent|||The queried objects' key that uses to join with objects that will come in the input JSON|
-|Key To Insert|key-to-insert|||A key that is used to insert the queried object in the main object.|
-|Path To Insert|path-to-insert|||A key that uses to insert queried objects in the objects that will come in the input JSON|
-|Clean Up Policy|clean-up-policy|NONE|NONE, SOURCE, TARGET|Defines cleanup policy for keys used in join:- TARGET: remove parent key- SOURCE: remove child key- NONE: don't remove any keys|
+|Database Connection Pooling Service|`Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the database.|
+|Prepared Statement Provider|`prepared-statement-provider-service`|||The Controller Service that is used to create a prepared statement.|
+|Batch Size|`internal-batch-size`|100||The maximum number of rows from the result set to be saved in single FlowFile.|
+|Fetch Size|`Fetch Size`|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Query|`db-fetch-sql-query`|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
+|Path|`path`|||A JsonPath expression that specifies path to source ID attribute inside the array in the incoming FlowFile.|
+|Join Key Parent With Child|`join-key-parent-with-child`|||The objects' key in the input JSON that uses to join with objects that will be queried|
+|Join Key Child With Parent|`Join Key Child With Parent`|||The queried objects' key that uses to join with objects that will come in the input JSON|
+|Key To Insert|`key-to-insert`|||A key that is used to insert the queried object in the main object.|
+|Path To Insert|`path-to-insert`|||A key that uses to insert queried objects in the objects that will come in the input JSON|
+|Clean Up Policy|`clean-up-policy`|NONE|NONE, SOURCE, TARGET|Defines cleanup policy for keys used in join:- TARGET: remove parent key- SOURCE: remove child key- NONE: don't remove any keys|
 
 ### QueryDatabaseToJson
 
@@ -62,12 +62,12 @@ identifiers in the JSON format.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
-|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
-|Batch Size|internal-batch-size|100||The maximum number of rows from the result set to be saved in single FlowFile.|
-|Fetch Size|Fetch Size|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
-|Query|db-fetch-sql-query|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
-|Path|path|||A JsonPath expression that specifies path to source ID attribute inside the array in an incoming FlowFile.|
+|Database Connection Pooling Service|`Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the database.|
+|Prepared Statement Provider|`prepared-statement-provider-service`|||The Controller Service that is used to create a prepared statement.|
+|Batch Size|`internal-batch-size`|100||The maximum number of rows from the result set to be saved in single FlowFile.|
+|Fetch Size|`Fetch Size`|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Query|`db-fetch-sql-query`|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
+|Path|`path`|||A JsonPath expression that specifies path to source ID attribute inside the array in an incoming FlowFile.|
 
 ### FetchTableToJson
 
@@ -84,13 +84,13 @@ will be performed.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
-|Table Name|table|||The name of the database table to be queried. If Custom Query is set, this property is ignored.|
-|Columns To Return|columns-to-return|||A comma-separated list of column names to be used in the query. If your database requires special treatment of the names (quoting, e.g.), each name should include such treatment. If no column names are supplied, all columns in the specified table will be returned. NOTE: It is important to use consistent column names for a given table for incremental fetch to work properly.|
-|Custom Query|custom-query|||Custom query. Would be used instead of tables and columns properties if specified.|
-|Batch Size|batch-size|1||The maximum number of rows from the result set to be saved in a single FlowFile.|
-|Fetch Size|fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
-|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|Database Connection Pooling Service|`Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the database.|
+|Table Name|`table`|||The name of the database table to be queried. If Custom Query is set, this property is ignored.|
+|Columns To Return|`columns-to-return`|||A comma-separated list of column names to be used in the query. If your database requires special treatment of the names (quoting, e.g.), each name should include such treatment. If no column names are supplied, all columns in the specified table will be returned. NOTE: It is important to use consistent column names for a given table for incremental fetch to work properly.|
+|Custom Query|`custom-query`|||Custom query. Would be used instead of tables and columns properties if specified.|
+|Batch Size|`batch-size`|1||The maximum number of rows from the result set to be saved in a single FlowFile.|
+|Fetch Size|`fetch-size`|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|`write-by-batch`|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### ValidateJson
 
@@ -102,11 +102,11 @@ Array with validation errors is added to the content of FlowFile.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|JSON Schema|validate-json-schema|||Validation JSON Schema|
-|Entity Type Path|be-type-path|_businessEntityType||A JsonPath expression that specifies path to business entity type attribute in the content of incoming FlowFile.|
-|ID Path|source-id-path|_sourceId||A JsonPath expression that specifies path to source ID attribute in the content of incoming FlowFile.|
-|Error Code|error-code|ME-JV-0002||Validation error code. Used as identification error code when formatting an array of validation errors.|
-|Wrapper regular expression|wrapper-regex|||Regular expression to define path of wrapper in aggregated business entity. If validation errors are detected and regular expression is set and matched, the wrapper path will be removed from the error path, ID of the wrapper will be replaced to ID of the business entity.|
+|JSON Schema|`validate-json-schema`|||Validation JSON Schema|
+|Entity Type Path|`be-type-path`|_businessEntityType||A JsonPath expression that specifies path to business entity type attribute in the content of incoming FlowFile.|
+|ID Path|`source-id-path`|_sourceId||A JsonPath expression that specifies path to source ID attribute in the content of incoming FlowFile.|
+|Error Code|`error-code`|ME-JV-0002||Validation error code. Used as identification error code when formatting an array of validation errors.|
+|Wrapper regular expression|`wrapper-regex`|||Regular expression to define path of wrapper in aggregated business entity. If validation errors are detected and regular expression is set and matched, the wrapper path will be removed from the error path, ID of the wrapper will be replaced to ID of the business entity.|
 
 ### BackupAttributes
 
@@ -114,8 +114,8 @@ Backups all FlowFile attributes by adding prefix to their names.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Prefix Attribute|prefix-attr|||FlowFile attribute to use as prefix for backup attributes|
-|Excluded Attributes|excluded-attrs-regex|||Regular expression defining attributes to exclude from backup|
+|Prefix Attribute|`prefix-attr`|||FlowFile attribute to use as prefix for backup attributes|
+|Excluded Attributes|`excluded-attrs-regex`|||Regular expression defining attributes to exclude from backup|
 
 ### PutGeneratedRecord
 
@@ -129,10 +129,10 @@ JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Sour
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Record Destination Service|put-record-sink|||The Controller Service which is used to send the result Record to some destination.|
-|Source type|source-type|dynamicProperties|Dynamic Properties, JSON Property|The source type that will be used to create the record. The record source can be a Dynamic Processor Property or a 'JSON Property' property.|
-|List JSON Dynamic Property|list-json-dynamic-property|||Comma-separated list of dynamic properties that contain JSON values|
-|JSON Property|json-property-object|||A complex JSON object for generating Record.A JSON object must have a flat structure without nested objects or arrays of non-scalar types. Object keys directly correspond to attribute names and are used as field names. All values must be scalar. Arrays containing only numeric values are allowed.|
+|Record Destination Service|`put-record-sink`|||The Controller Service which is used to send the result Record to some destination.|
+|Source type|`source-type`|dynamicProperties|Dynamic Properties, JSON Property|The source type that will be used to create the record. The record source can be a Dynamic Processor Property or a 'JSON Property' property.|
+|List JSON Dynamic Property|`list-json-dynamic-property`|||Comma-separated list of dynamic properties that contain JSON values|
+|JSON Property|`json-property-object`|||A complex JSON object for generating Record.A JSON object must have a flat structure without nested objects or arrays of non-scalar types. Object keys directly correspond to attribute names and are used as field names. All values must be scalar. Arrays containing only numeric values are allowed.|
 
 ### QueryDatabaseToCSV
 
@@ -141,34 +141,34 @@ The processor allows to split query result into several FlowFiles and select CSV
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
-|Custom Query|custom-query|||Query to run against DB to get CSV data from.|
-|CSV Format|csv-format|Default|Default, Excel, InformixUnload, InformixUnloadCsv, MongoDBCsv, MongoDBTsv, MySQL, Oracle, PostgreSQLCsv, PostgreSQLText, RFC4180, TDF|CSV Format to use for data extraction|
-|Batch Size|batch-size|0||The maximum number of rows from the result set to be saved in a single FlowFile. If set to 0, then the whole result set is saved to a single FlowFile.|
-|Fetch Size|fetch-size|10000||The number of result rows to be fetched from the result set at a time.  This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
-|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|Database Connection Pooling Service|`Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the database.|
+|Custom Query|`custom-query`|||Query to run against DB to get CSV data from.|
+|CSV Format|`csv-format`|Default|Default, Excel, InformixUnload, InformixUnloadCsv, MongoDBCsv, MongoDBTsv, MySQL, Oracle, PostgreSQLCsv, PostgreSQLText, RFC4180, TDF|CSV Format to use for data extraction|
+|Batch Size|`batch-size`|0||The maximum number of rows from the result set to be saved in a single FlowFile. If set to 0, then the whole result set is saved to a single FlowFile.|
+|Fetch Size|`fetch-size`|10000||The number of result rows to be fetched from the result set at a time.  This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|`write-by-batch`|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### QueryIdsAndFetchTableToJson
 
 Fetches data from source DB into JSON using query (Custom Query) and
- ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then
- for each batch of ids, main query is executed to get data and transform it to JSON. Data is
+ IDs obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then
+ for each batch of IDs, main query is executed to get data and transform it to JSON. Data is
 collected until Batch Size is reached, then it is loaded into FlowFile.
  Data collection continues until all rows are processed.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the source database.|
-|IDs Database Connection Pooling Service|Ids Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the mapping database.|
-|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
-|Custom Query|custom-query|||Custom query for Source Data Base.|
-|IDs Custom Query|ids-custom-query|\${mapping.db.query}||Custom request to get a list of IDs.|
-|Batch Size|batch-size|1||The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile.|
-|IDs Batch Size|ids-batch-size|1||The maximum number of rows in table from IDs database from the result.|
-|Fetch Size|fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored.|
-|IDs Fetch Size|ids-fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
-|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
-|IDs Write By Batch|ids-write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|Database Connection Pooling Service|`Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the source database.|
+|IDs Database Connection Pooling Service|`Ids Database Connection Pooling Service`|||The Controller Service that is used to obtain a connection to the IDs database.|
+|Prepared Statement Provider|`prepared-statement-provider-service`|||The Controller Service that is used to create a prepared statement.|
+|Custom Query|`custom-query`|||Custom query for Source Data Base.|
+|IDs Custom Query|`ids-custom-query`|\${mapping.db.query}||Custom request to get a list of IDs.|
+|Batch Size|`batch-size`|1||The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile.|
+|IDs Batch Size|`ids-batch-size`|1||The maximum number of rows in table from IDs database from the result.|
+|Fetch Size|`fetch-size`|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored.|
+|IDs Fetch Size|`ids-fetch-size`|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|`write-by-batch`|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|IDs Write By Batch|`ids-write-by-batch`|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### PutSQLRecord
 
@@ -177,11 +177,11 @@ FlowFile are processed within single transaction.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Record Reader|record-reader|||Record Reader|
-|SQL Statement|sql-statement|||SQL statement that should be executed for each record. Statement must contains exactly the same number and types of binds as number and types of fields in RecordSchema.|
-|Database Connection Pooling Service|dbcp-service|||Database Connection Pooling Service to use for connecting to target Database|
-|Maximum Batch Size|max-batch-size|100||Maximum number of records to include into DB batch|
-|Convert Payload|convert-payload|false|true, false|When set to true, Map/Record/Array/Choice fields will be converted to JSON strings. Otherwise processor will throw exception, if Map/Record/Array/Choice fields are present in the input Record. By default is set to false.|
+|Record Reader|`record-reader`|||Record Reader|
+|SQL Statement|`sql-statement`|||SQL statement that should be executed for each record. Statement must contains exactly the same number and types of binds as number and types of fields in RecordSchema.|
+|Database Connection Pooling Service|`dbcp-service`|||Database Connection Pooling Service to use for connecting to target Database|
+|Maximum Batch Size|`max-batch-size`|100||Maximum number of records to include into DB batch|
+|Convert Payload|`convert-payload`|false|true, false|When set to true, Map/Record/Array/Choice fields will be converted to JSON strings. Otherwise processor will throw exception, if Map/Record/Array/Choice fields are present in the input Record. By default is set to false.|
 
 ### PostgreSQLBulkLoader
 
@@ -190,12 +190,12 @@ It is also possible to copy from DB to FlowFile content.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Connection Pooling Service|dbcp-service|||Database Connection Pooling Service to use for connecting to target Database.|
-|SQL Query|sql-query|||SQL query to execute. Copy command from stdin/to stdout.|
-|File Path|file-path|||Path to CSV file in file system.|
-|Buffer Size|buffer-size|||Number of characters to buffer and push over network to server at once.|
-|Copy Mode|copy-mode|to|To, From|Provides a selection of copy mode (from stdin/to stdout).|
-|Read From|read-from|file-system|File System, Content|Provides a selection of data to copy.|
+|Database Connection Pooling Service|`dbcp-service`|||Database Connection Pooling Service to use for connecting to target Database.|
+|SQL Query|`sql-query`|||SQL query to execute. Copy command from stdin/to stdout.|
+|File Path|`file-path`|||Path to CSV file in file system.|
+|Buffer Size|`buffer-size`|||Number of characters to buffer and push over network to server at once.|
+|Copy Mode|`copy-mode`|to|To, From|Provides a selection of copy mode (from stdin/to stdout).|
+|Read From|`read-from`|file-system|File System, Content|Provides a selection of data to copy.|
 <!-- End of additional processors properties description. DO NOT REMOVE. -->
 
 ## Additional controller services
@@ -208,12 +208,12 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 |Controller Service|NAR|Description|
 |---|---|---|
-|RedisBulkDistributedMapCacheClientService|qubership-nifi-bulk-redis-nar|Provides a Redis-based distributed map cache client with bulk operation support. This service enables efficient batch operations on Redis cache, including bulk get-and-put-if-absent and bulk remove operations. It uses Lua scripting for atomic bulk operations and supports configurable TTL (time-to-live) for cached entries. The service is particularly useful for high-performance scenarios requiring atomic bulk cache operations across multiple NiFi instances.|
-|OraclePreparedStatementWithArrayProvider|qubership-service-nar|Provides a prepared statement service.|
-|PostgresPreparedStatementWithArrayProvider|qubership-service-nar|Provides a prepared statement service.|
-|JsonContentValidator|qubership-service-nar|Provides validate method to check the JSON against a given schema.|
-|QubershipPrometheusRecordSink|qubership-service-nar|A Record Sink service that exposes metrics to Prometheus via an embedded HTTP server on a configurable port. Collects metrics from incoming records by treating string fields as labels, numeric fields as gauges, and nested records (with 'type' and 'value' fields) as counters or distribution summaries.|
-|HttpLookupService|qubership-nifi-lookup-service-nar|Sends HTTP GET request with specified URL and headers (set up via dynamic PROPERTY_DESCRIPTORS) to look up values. If the response status code is 2xx, the response body is parsed with Record Reader and returned as array of records. Otherwise (status code other than 2xx), the controller service throws exception and logs the response body.|
+|`RedisBulkDistributedMapCacheClientService`|qubership-nifi-bulk-redis-nar|Provides a Redis-based distributed map cache client with bulk operation support. This service enables efficient batch operations on Redis cache, including bulk get-and-put-if-absent and bulk remove operations. It uses Lua scripting for atomic bulk operations and supports configurable TTL (time-to-live) for cached entries. The service is particularly useful for high-performance scenarios requiring atomic bulk cache operations across multiple NiFi instances.|
+|`OraclePreparedStatementWithArrayProvider`|qubership-service-nar|Provides a prepared statement service.|
+|`PostgresPreparedStatementWithArrayProvider`|qubership-service-nar|Provides a prepared statement service.|
+|`JsonContentValidator`|qubership-service-nar|Provides validate method to check the JSON against a given schema.|
+|`QubershipPrometheusRecordSink`|qubership-service-nar|A Record Sink service that exposes metrics to Prometheus via an embedded HTTP server on a configurable port. Collects metrics from incoming records by treating string fields as labels, numeric fields as gauges, and nested records (with 'type' and 'value' fields) as counters or distribution summaries.|
+|`HttpLookupService`|qubership-nifi-lookup-service-nar|Sends HTTP GET request with specified URL and headers (set up via dynamic PROPERTY_DESCRIPTORS) to look up values. If the response status code is 2xx, the response body is parsed with Record Reader and returned as array of records. Otherwise (status code other than 2xx), the controller service throws exception and logs the response body.|
 
 ## Additional controller services properties description
 
@@ -229,8 +229,8 @@ requiring atomic bulk cache operations across multiple NiFi instances.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Redis Connection Pool|redis-connection-pool|||A service that provides connections to Redis.|
-|TTL|redis-cache-ttl|0 secs||Indicates how long the data should exist in Redis.Setting '0 secs' would mean the data would exist forever|
+|Redis Connection Pool|`redis-connection-pool`|||A service that provides connections to Redis.|
+|TTL|`redis-cache-ttl`|0 secs||Indicates how long the data should exist in Redis.Setting '0 secs' would mean the data would exist forever|
 
 ### OraclePreparedStatementWithArrayProvider
 
@@ -238,9 +238,9 @@ Provides a prepared statement service.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Schema Name|dbSchema|||Owner of the array type|
-|Char Array Type|array-type|ARRAYOFSTRINGS||Character-based array type.|
-|Numeric Array Type|num-array-type|ARRAYOFNUMBERS||Numeric array type.|
+|Schema Name|`dbSchema`|||Owner of the array type|
+|Char Array Type|`array-type`|ARRAYOFSTRINGS||Character-based array type.|
+|Numeric Array Type|`num-array-type`|ARRAYOFNUMBERS||Numeric array type.|
 
 ### PostgresPreparedStatementWithArrayProvider
 
@@ -248,8 +248,8 @@ Provides a prepared statement service.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Char Array Type|array-type|text||Character array base type.|
-|Numeric Array Type|numeric-array-type|numeric||Numeric array base type.|
+|Char Array Type|`array-type`|text||Character array base type.|
+|Numeric Array Type|`numeric-array-type`|numeric||Numeric array base type.|
 
 ### JsonContentValidator
 
@@ -257,7 +257,7 @@ Provides validate method to check the JSON against a given schema.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Schema|schema|||Validation JSON Schema.|
+|Schema|`schema`|||Validation JSON Schema.|
 
 ### QubershipPrometheusRecordSink
 
@@ -268,9 +268,9 @@ as counters or distribution summaries.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Prometheus Metrics Endpoint Port|prometheus-sink-metrics-endpoint-port|9092||The Port where prometheus metrics can be scraped from.|
-|Instance ID|prometheus-sink-instance-id|\${hostname(true)}_\${NAMESPACE}||Identifier of the NiFi instance to be included in the metrics as a label.|
-|Clear Metrics on Disable|prometheus-sink-clear-metrics|No|Yes, No|If set to Yes, all metrics stored in the controller service are cleared, when the controller service is disabled. By default, metrics are not cleared.|
+|Prometheus Metrics Endpoint Port|`prometheus-sink-metrics-endpoint-port`|9092||The Port where prometheus metrics can be scraped from.|
+|Instance ID|`prometheus-sink-instance-id`|\${hostname(true)}_\${NAMESPACE}||Identifier of the NiFi instance to be included in the metrics as a label.|
+|Clear Metrics on Disable|`prometheus-sink-clear-metrics`|No|Yes, No|If set to Yes, all metrics stored in the controller service are cleared, when the controller service is disabled. By default, metrics are not cleared.|
 
 ### HttpLookupService
 
@@ -280,10 +280,10 @@ Otherwise (status code other than 2xx), the controller service throws exception 
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|URL|http-lookup-url|||The URL to send request to. Expression language is supported and evaluated against both the lookup key-value pairs and FlowFile attributes.|
-|Record Reader|http-lookup-record-reader|||The record reader to use for loading response body and handling it as a record set.|
-|Connection Timeout|http-lookup-connection-timeout|5 secs||Max wait time for connection to remote service.|
-|Read Timeout|http-lookup-read-timeout|15 secs||Max wait time for response from remote service.|
+|URL|`http-lookup-url`|||The URL to send request to. Expression language is supported and evaluated against both the lookup key-value pairs and FlowFile attributes.|
+|Record Reader|`http-lookup-record-reader`|||The record reader to use for loading response body and handling it as a record set.|
+|Connection Timeout|`http-lookup-connection-timeout`|5 secs||Max wait time for connection to remote service.|
+|Read Timeout|`http-lookup-read-timeout`|15 secs||Max wait time for response from remote service.|
 <!-- End of additional controller services description. DO NOT REMOVE. -->
 
 ## Additional reporting tasks
@@ -296,9 +296,9 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 |Reporting Task|NAR|Description|
 |---|---|---|
-|ComponentMetricsReportingTask|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to InfluxDB.|
-|CommonMetricsReportingTask|migration-nifi-processors-open|Sends Nifi metrics to InfluxDB.|
-|ComponentPrometheusReportingTask|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to Prometheus.|
+|`ComponentMetricsReportingTask`|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to InfluxDB.|
+|`CommonMetricsReportingTask`|migration-nifi-processors-open|Sends Nifi metrics to InfluxDB.|
+|`ComponentPrometheusReportingTask`|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to Prometheus.|
 
 ## Additional reporting tasks properties description
 
@@ -310,17 +310,17 @@ Sends components (Processors, Connections) metrics to InfluxDB.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Name|influxdb-dbname|monitoring_server||InfluxDB database|
-|InfluxDB URL|influxdb-url|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
-|Connection timeout|Connection timeout|0 seconds||The maximum time for establishing connection to the InfluxDB|
-|Username|influxdb-username|||Username for accessing InfluxDB|
-|Password|influxdb-password|||Password for accessing InfluxDB|
-|Character Set|influxdb-charset|UTF-8||Specifies the character set of the document data.|
-|Consistency Level|influxdb-consistency-level|ONE|One, Any, All, Quorum|InfluxDB consistency level|
-|Retention Policy|influxdb-retention-policy|monitor||Retention policy for the saving the records|
-|Max size of records|influxdb-max-records-size|1 MB||Maximum size of records allowed to be posted in one batch|
-|Processor time threshold|processor-time-threshold|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in InfluxDB.|
-|Connection queue threshold|connection-queue-threshold|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in InfluxDB.|
+|Database Name|`influxdb-dbname`|monitoring_server||InfluxDB database|
+|InfluxDB URL|`influxdb-url`|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
+|Connection timeout|`Connection timeout`|0 seconds||The maximum time for establishing connection to the InfluxDB|
+|Username|`influxdb-username`|||Username for accessing InfluxDB|
+|Password|`influxdb-password`|||Password for accessing InfluxDB|
+|Character Set|`influxdb-charset`|UTF-8||Specifies the character set of the document data.|
+|Consistency Level|`influxdb-consistency-level`|ONE|One, Any, All, Quorum|InfluxDB consistency level|
+|Retention Policy|`influxdb-retention-policy`|monitor||Retention policy for the saving the records|
+|Max size of records|`influxdb-max-records-size`|1 MB||Maximum size of records allowed to be posted in one batch|
+|Processor time threshold|`processor-time-threshold`|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in InfluxDB.|
+|Connection queue threshold|`connection-queue-threshold`|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in InfluxDB.|
 
 ### CommonMetricsReportingTask
 
@@ -328,15 +328,15 @@ Sends Nifi metrics to InfluxDB.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Database Name|influxdb-dbname|monitoring_server||InfluxDB database|
-|InfluxDB URL|influxdb-url|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
-|Connection timeout|Connection timeout|0 seconds||The maximum time for establishing connection to the InfluxDB|
-|Username|influxdb-username|||Username for accessing InfluxDB|
-|Password|influxdb-password|||Password for accessing InfluxDB|
-|Character Set|influxdb-charset|UTF-8||Specifies the character set of the document data.|
-|Consistency Level|influxdb-consistency-level|ONE|One, Any, All, Quorum|InfluxDB consistency level|
-|Retention Policy|influxdb-retention-policy|monitor||Retention policy for the saving the records|
-|Max size of records|influxdb-max-records-size|1 MB||Maximum size of records allowed to be posted in one batch|
+|Database Name|`influxdb-dbname`|monitoring_server||InfluxDB database|
+|InfluxDB URL|`influxdb-url`|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
+|Connection timeout|`Connection timeout`|0 seconds||The maximum time for establishing connection to the InfluxDB|
+|Username|`influxdb-username`|||Username for accessing InfluxDB|
+|Password|`influxdb-password`|||Password for accessing InfluxDB|
+|Character Set|`influxdb-charset`|UTF-8||Specifies the character set of the document data.|
+|Consistency Level|`influxdb-consistency-level`|ONE|One, Any, All, Quorum|InfluxDB consistency level|
+|Retention Policy|`influxdb-retention-policy`|monitor||Retention policy for the saving the records|
+|Max size of records|`influxdb-max-records-size`|1 MB||Maximum size of records allowed to be posted in one batch|
 
 ### ComponentPrometheusReportingTask
 
@@ -344,9 +344,9 @@ Sends components (Processors, Connections) metrics to Prometheus.
 
 |Display Name|API Name|Default Value|Allowable Values|Description|
 |---|---|---|---|---|
-|Server Port|port|9192||The Port where prometheus metrics can be accessed.|
-|Meter Registry Provider|meter-registry-provider|||Identifier of Controller Services, which is used to obtain the Meter Registry.|
-|Processor time threshold|processor-time-threshold|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in Prometheus.|
-|Connection queue threshold|connection-queue-threshold|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in Prometheus.|
-|Process group level threshold|pg-level-threshold|2||Maximum depth of process group to report in monitoring.Limits data volume collected in Prometheus.|
+|Server Port|`port`|9192||The Port where prometheus metrics can be accessed.|
+|Meter Registry Provider|`meter-registry-provider`|||Identifier of Controller Services, which is used to obtain the Meter Registry.|
+|Processor time threshold|`processor-time-threshold`|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in Prometheus.|
+|Connection queue threshold|`connection-queue-threshold`|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in Prometheus.|
+|Process group level threshold|`pg-level-threshold`|2||Maximum depth of process group to report in monitoring.Limits data volume collected in Prometheus.|
 <!-- End of additional reporting tasks description. DO NOT REMOVE. -->

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,18 +12,18 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 <!-- Table for additional processors. DO NOT REMOVE. -->
 
-| Processor  | NAR                 | Description        |
-|----------------------|--------------------|--------------------|
-| QueryDatabaseToJsonWithMerge | migration-nifi-processors-open | Executes custom query to fetch rows from table and merge them with the main JSON object which is in the content of incoming FlowFile.  The Path property supports JsonPath syntax to find source ID attributes in the main object.  The main and queried objects are merged by join key properties.You can specify where exactly to insert queried objects and by what key with path  to insert and key to insert properties. |
-| QueryDatabaseToJson | migration-nifi-processors-open | Fetches data from database table and transforms it to JSON.This processor gets incoming FlowFile and reads ID attributes using JSON Path. Found IDs are passedin select query as an array. Obtained result set will be written into output FlowFile.Expects that content of an incoming FlowFile is array of unique business entity identifiers in the JSON format. |
-| FetchTableToJson | migration-nifi-processors-open | Fetches data from DB table into JSON using either query (Custom Query) or table (Table) and  list of columns (Columns To Return). This processor works in batched mode: it collects FlowFiles until  batch size limit is reached and then processes batch. This processor can accept incoming connections;  the behavior of the processor is different whether incoming connections are provided: -If no incoming connection(s) are specified, the processor will generate SQL queries on the specified  processor schedule. -If incoming connection(s) are specified and no FlowFile is available to a processor task, no work will be performed. -If incoming connection(s) are specified and a FlowFile is available to a processor task, query  will be executed when processing the next FlowFile. |
-| ValidateJson | migration-nifi-processors-open | Validates the content of FlowFiles against the JSON schema. The FlowFiles that are successfully validated against the specified schema are routed to valid relationship without any changes. The FlowFiles that are not valid according to the schema are routed to invalid relationship. Array with validation errors is added to the content of FlowFile. |
-| BackupAttributes | migration-nifi-processors-open | Backups all FlowFile attributes by adding prefix to their names. |
-| PutGeneratedRecord | migration-nifi-processors-open | A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'. |
-| QueryDatabaseToCSV | migration-nifi-processors-open | Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output. |
-| QueryIdsAndFetchTableToJson | migration-nifi-processors-open |  |
-| PutSQLRecord | qubership-nifi-db-processors-nar | Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction. |
-| PostgreSQLBulkLoader | qubership-nifi-db-processors-nar | The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content. |
+|Processor|NAR|Description|
+|---|---|---|
+|QueryDatabaseToJsonWithMerge|migration-nifi-processors-open|Executes custom query to fetch rows from table and merge them with the main JSON object which is in the content of incoming FlowFile.  The Path property supports JsonPath syntax to find source ID attributes in the main object.  The main and queried objects are merged by join key properties.You can specify where exactly to insert queried objects and by what key with path  to insert and key to insert properties.|
+|QueryDatabaseToJson|migration-nifi-processors-open|Fetches data from database table and transforms it to JSON.This processor gets incoming FlowFile and reads ID attributes using JSON Path. Found IDs are passedin select query as an array. Obtained result set will be written into output FlowFile.Expects that content of an incoming FlowFile is array of unique business entity identifiers in the JSON format.|
+|FetchTableToJson|migration-nifi-processors-open|Fetches data from DB table into JSON using either query (Custom Query) or table (Table) and  list of columns (Columns To Return). This processor works in batched mode: it collects FlowFiles until  batch size limit is reached and then processes batch. This processor can accept incoming connections;  the behavior of the processor is different whether incoming connections are provided: -If no incoming connection(s) are specified, the processor will generate SQL queries on the specified  processor schedule. -If incoming connection(s) are specified and no FlowFile is available to a processor task, no work will be performed. -If incoming connection(s) are specified and a FlowFile is available to a processor task, query  will be executed when processing the next FlowFile.|
+|ValidateJson|migration-nifi-processors-open|Validates the content of FlowFiles against the JSON schema. The FlowFiles that are successfully validated against the specified schema are routed to valid relationship without any changes. The FlowFiles that are not valid according to the schema are routed to invalid relationship. Array with validation errors is added to the content of FlowFile.|
+|BackupAttributes|migration-nifi-processors-open|Backups all FlowFile attributes by adding prefix to their names.|
+|PutGeneratedRecord|migration-nifi-processors-open|A processor that generates Records based on its properties and sends them to a destination specified by a Record Destination Service (i.e., record sink). The record source is defined by the 'Source Type' property, which can be either 'Dynamic Properties' or 'JSON Property'. If 'Source Type' is set to 'Dynamic Properties', each dynamic property becomes a field in the Record, with the field type automatically determined by the value type: string, double, or Record (if the dynamic property contains a JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'.|
+|QueryDatabaseToCSV|migration-nifi-processors-open|Fetches data from DB using specified query and transforms it to CSV in particular CSV format.The processor allows to split query result into several FlowFiles and select CSV format for output.|
+|QueryIdsAndFetchTableToJson|migration-nifi-processors-open||
+|PutSQLRecord|qubership-nifi-db-processors-nar|Executes given SQL statement using data from input records. All records within single  FlowFile are processed within single transaction.|
+|PostgreSQLBulkLoader|qubership-nifi-db-processors-nar|The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.It is also possible to copy from DB to FlowFile content.|
 
 ## Additional processors properties description
 
@@ -38,19 +38,19 @@ which is in the content of incoming FlowFile.
 You can specify where exactly to insert queried objects and by what key with path
  to insert and key to insert properties.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the database. |
-| Prepared Statement Provider | prepared-statement-provider-service |  |  | The Controller Service that is used to create a prepared statement. |
-| Batch Size | internal-batch-size | 100 |  | The maximum number of rows from the result set to be saved in single FlowFile. |
-| Fetch Size | Fetch Size | 1000 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
-| Query | db-fetch-sql-query |  |  | A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement. |
-| Path | path |  |  | A JsonPath expression that specifies path to source ID attribute inside the array in the incoming FlowFile. |
-| Join Key Parent With Child | join-key-parent-with-child |  |  | The objects' key in the input JSON that uses to join with objects that will be queried |
-| Join Key Child With Parent | Join Key Child With Parent |  |  | The queried objects' key that uses to join with objects that will come in the input JSON |
-| Key To Insert | key-to-insert |  |  | A key that is used to insert the queried object in the main object. |
-| Path To Insert | path-to-insert |  |  | A key that uses to insert queried objects in the objects that will come in the input JSON |
-| Clean Up Policy | clean-up-policy | NONE | NONE, SOURCE, TARGET | Defines cleanup policy for keys used in join:- TARGET: remove parent key- SOURCE: remove child key- NONE: don't remove any keys |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
+|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
+|Batch Size|internal-batch-size|100||The maximum number of rows from the result set to be saved in single FlowFile.|
+|Fetch Size|Fetch Size|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Query|db-fetch-sql-query|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
+|Path|path|||A JsonPath expression that specifies path to source ID attribute inside the array in the incoming FlowFile.|
+|Join Key Parent With Child|join-key-parent-with-child|||The objects' key in the input JSON that uses to join with objects that will be queried|
+|Join Key Child With Parent|Join Key Child With Parent|||The queried objects' key that uses to join with objects that will come in the input JSON|
+|Key To Insert|key-to-insert|||A key that is used to insert the queried object in the main object.|
+|Path To Insert|path-to-insert|||A key that uses to insert queried objects in the objects that will come in the input JSON|
+|Clean Up Policy|clean-up-policy|NONE|NONE, SOURCE, TARGET|Defines cleanup policy for keys used in join:- TARGET: remove parent key- SOURCE: remove child key- NONE: don't remove any keys|
 
 ### QueryDatabaseToJson
 
@@ -60,14 +60,14 @@ in select query as an array. Obtained result set will be written into output Flo
 Expects that content of an incoming FlowFile is array of unique business entity
 identifiers in the JSON format.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the database. |
-| Prepared Statement Provider | prepared-statement-provider-service |  |  | The Controller Service that is used to create a prepared statement. |
-| Batch Size | internal-batch-size | 100 |  | The maximum number of rows from the result set to be saved in single FlowFile. |
-| Fetch Size | Fetch Size | 1000 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
-| Query | db-fetch-sql-query |  |  | A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement. |
-| Path | path |  |  | A JsonPath expression that specifies path to source ID attribute inside the array in an incoming FlowFile. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
+|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
+|Batch Size|internal-batch-size|100||The maximum number of rows from the result set to be saved in single FlowFile.|
+|Fetch Size|Fetch Size|1000||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Query|db-fetch-sql-query|||A custom SQL query used to retrieve data. Instead of building a SQL query from other properties, this query will be wrapped as a sub-query. Query must have no ORDER BY statement.|
+|Path|path|||A JsonPath expression that specifies path to source ID attribute inside the array in an incoming FlowFile.|
 
 ### FetchTableToJson
 
@@ -82,15 +82,15 @@ will be performed.
 -If incoming connection(s) are specified and a FlowFile is available to a processor task, query
  will be executed when processing the next FlowFile.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the database. |
-| Table Name | table |  |  | The name of the database table to be queried. If Custom Query is set, this property is ignored. |
-| Columns To Return | columns-to-return |  |  | A comma-separated list of column names to be used in the query. If your database requires special treatment of the names (quoting, e.g.), each name should include such treatment. If no column names are supplied, all columns in the specified table will be returned. NOTE: It is important to use consistent column names for a given table for incremental fetch to work properly. |
-| Custom Query | custom-query |  |  | Custom query. Would be used instead of tables and columns properties if specified. |
-| Batch Size | batch-size | 1 |  | The maximum number of rows from the result set to be saved in a single FlowFile. |
-| Fetch Size | fetch-size | 1 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
-| Write By Batch | write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
+|Table Name|table|||The name of the database table to be queried. If Custom Query is set, this property is ignored.|
+|Columns To Return|columns-to-return|||A comma-separated list of column names to be used in the query. If your database requires special treatment of the names (quoting, e.g.), each name should include such treatment. If no column names are supplied, all columns in the specified table will be returned. NOTE: It is important to use consistent column names for a given table for incremental fetch to work properly.|
+|Custom Query|custom-query|||Custom query. Would be used instead of tables and columns properties if specified.|
+|Batch Size|batch-size|1||The maximum number of rows from the result set to be saved in a single FlowFile.|
+|Fetch Size|fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### ValidateJson
 
@@ -100,22 +100,22 @@ relationship without any changes.
 The FlowFiles that are not valid according to the schema are routed to invalid relationship.
 Array with validation errors is added to the content of FlowFile.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| JSON Schema | validate-json-schema |  |  | Validation JSON Schema |
-| Entity Type Path | be-type-path | _businessEntityType |  | A JsonPath expression that specifies path to business entity type attribute in the content of incoming FlowFile. |
-| ID Path | source-id-path | _sourceId |  | A JsonPath expression that specifies path to source ID attribute in the content of incoming FlowFile. |
-| Error Code | error-code | ME-JV-0002 |  | Validation error code. Used as identification error code when formatting an array of validation errors. |
-| Wrapper regular expression | wrapper-regex |  |  | Regular expression to define path of wrapper in aggregated business entity. If validation errors are detected and regular expression is set and matched, the wrapper path will be removed from the error path, ID of the wrapper will be replaced to ID of the business entity. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|JSON Schema|validate-json-schema|||Validation JSON Schema|
+|Entity Type Path|be-type-path|_businessEntityType||A JsonPath expression that specifies path to business entity type attribute in the content of incoming FlowFile.|
+|ID Path|source-id-path|_sourceId||A JsonPath expression that specifies path to source ID attribute in the content of incoming FlowFile.|
+|Error Code|error-code|ME-JV-0002||Validation error code. Used as identification error code when formatting an array of validation errors.|
+|Wrapper regular expression|wrapper-regex|||Regular expression to define path of wrapper in aggregated business entity. If validation errors are detected and regular expression is set and matched, the wrapper path will be removed from the error path, ID of the wrapper will be replaced to ID of the business entity.|
 
 ### BackupAttributes
 
 Backups all FlowFile attributes by adding prefix to their names.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Prefix Attribute | prefix-attr |  |  | FlowFile attribute to use as prefix for backup attributes |
-| Excluded Attributes | excluded-attrs-regex |  |  | Regular expression defining attributes to exclude from backup |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Prefix Attribute|prefix-attr|||FlowFile attribute to use as prefix for backup attributes|
+|Excluded Attributes|excluded-attrs-regex|||Regular expression defining attributes to exclude from backup|
 
 ### PutGeneratedRecord
 
@@ -127,71 +127,71 @@ automatically determined by the value type: string, double, or Record (if the dy
 JSON value and is listed in the 'List JSON Dynamic Property' property). If 'Source Type' is set to
 'JSON Property', the Record is generated directly from the JSON value in the 'JSON Property'.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Record Destination Service | put-record-sink |  |  | The Controller Service which is used to send the result Record to some destination. |
-| Source type | source-type | dynamicProperties | Dynamic Properties, JSON Property | The source type that will be used to create the record. The record source can be a Dynamic Processor Property or a 'JSON Property' property. |
-| List JSON Dynamic Property | list-json-dynamic-property |  |  | Comma-separated list of dynamic properties that contain JSON values |
-| JSON Property | json-property-object |  |  | A complex JSON object for generating Record.A JSON object must have a flat structure without nested objects or arrays of non-scalar types. Object keys directly correspond to attribute names and are used as field names. All values must be scalar. Arrays containing only numeric values are allowed. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Record Destination Service|put-record-sink|||The Controller Service which is used to send the result Record to some destination.|
+|Source type|source-type|dynamicProperties|Dynamic Properties, JSON Property|The source type that will be used to create the record. The record source can be a Dynamic Processor Property or a 'JSON Property' property.|
+|List JSON Dynamic Property|list-json-dynamic-property|||Comma-separated list of dynamic properties that contain JSON values|
+|JSON Property|json-property-object|||A complex JSON object for generating Record.A JSON object must have a flat structure without nested objects or arrays of non-scalar types. Object keys directly correspond to attribute names and are used as field names. All values must be scalar. Arrays containing only numeric values are allowed.|
 
 ### QueryDatabaseToCSV
 
 Fetches data from DB using specified query and transforms it to CSV in particular CSV format.
 The processor allows to split query result into several FlowFiles and select CSV format for output.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the database. |
-| Custom Query | custom-query |  |  | Query to run against DB to get CSV data from. |
-| CSV Format | csv-format | Default | Default, Excel, InformixUnload, InformixUnloadCsv, MongoDBCsv, MongoDBTsv, MySQL, Oracle, PostgreSQLCsv, PostgreSQLText, RFC4180, TDF | CSV Format to use for data extraction |
-| Batch Size | batch-size | 0 |  | The maximum number of rows from the result set to be saved in a single FlowFile. If set to 0, then the whole result set is saved to a single FlowFile. |
-| Fetch Size | fetch-size | 10000 |  | The number of result rows to be fetched from the result set at a time.  This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
-| Write By Batch | write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the database.|
+|Custom Query|custom-query|||Query to run against DB to get CSV data from.|
+|CSV Format|csv-format|Default|Default, Excel, InformixUnload, InformixUnloadCsv, MongoDBCsv, MongoDBTsv, MySQL, Oracle, PostgreSQLCsv, PostgreSQLText, RFC4180, TDF|CSV Format to use for data extraction|
+|Batch Size|batch-size|0||The maximum number of rows from the result set to be saved in a single FlowFile. If set to 0, then the whole result set is saved to a single FlowFile.|
+|Fetch Size|fetch-size|10000||The number of result rows to be fetched from the result set at a time.  This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### QueryIdsAndFetchTableToJson
 
 
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the source database. |
-| Ids Database Connection Pooling Service | Ids Database Connection Pooling Service |  |  | The Controller Service that is used to obtain a connection to the mapping database. |
-| Prepared Statement Provider | prepared-statement-provider-service |  |  | The Controller Service that is used to create a prepared statement. |
-| Custom Query | custom-query |  |  | Custom query for Source Data Base. |
-| Ids Custom Query | ids-custom-query | ${mapping.db.query} |  | Custom request to get a list of id. |
-| Batch Size | batch-size | 1 |  | The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile. |
-| Ids Batch Size | ids-batch-size | 1 |  | The maximum number of rows in table from ids database from the result. |
-| Fetch Size | fetch-size | 1 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored. |
-| Ids Fetch Size | ids-fetch-size | 1 |  | The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored. |
-| Write By Batch | write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
-| Ids Write By Batch | ids-write-by-batch | false | true, false | Write a type that corresponds to the behavior of appearing FlowFiles in the queue. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the source database.|
+|Ids Database Connection Pooling Service|Ids Database Connection Pooling Service|||The Controller Service that is used to obtain a connection to the mapping database.|
+|Prepared Statement Provider|prepared-statement-provider-service|||The Controller Service that is used to create a prepared statement.|
+|Custom Query|custom-query|||Custom query for Source Data Base.|
+|Ids Custom Query|ids-custom-query|\${mapping.db.query}||Custom request to get a list of id.|
+|Batch Size|batch-size|1||The maximum number of rows in table from source database from the result set to be saved  in a single FlowFile.|
+|Ids Batch Size|ids-batch-size|1||The maximum number of rows in table from ids database from the result.|
+|Fetch Size|fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact.  If the value specified is zero, then the hint is ignored.|
+|Ids Fetch Size|ids-fetch-size|1||The number of result rows to be fetched from the result set at a time. This is a hint to the database driver and may not be honored and/or exact. If the value specified is zero, then the hint is ignored.|
+|Write By Batch|write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
+|Ids Write By Batch|ids-write-by-batch|false|true, false|Write a type that corresponds to the behavior of appearing FlowFiles in the queue.|
 
 ### PutSQLRecord
 
 Executes given SQL statement using data from input records. All records within single
 FlowFile are processed within single transaction.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Record Reader | record-reader |  |  | Record Reader |
-| SQL Statement | sql-statement |  |  | SQL statement that should be executed for each record. Statement must contains exactly the same number and types of binds as number and types of fields in RecordSchema. |
-| Database Connection Pooling Service | dbcp-service |  |  | Database Connection Pooling Service to use for connecting to target Database |
-| Maximum Batch Size | max-batch-size | 100 |  | Maximum number of records to include into DB batch |
-| Convert Payload | convert-payload | false | true, false | When set to true, Map/Record/Array/Choice fields will be converted to JSON strings. Otherwise processor will throw exception, if Map/Record/Array/Choice fields are present in the input Record. By default is set to false. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Record Reader|record-reader|||Record Reader|
+|SQL Statement|sql-statement|||SQL statement that should be executed for each record. Statement must contains exactly the same number and types of binds as number and types of fields in RecordSchema.|
+|Database Connection Pooling Service|dbcp-service|||Database Connection Pooling Service to use for connecting to target Database|
+|Maximum Batch Size|max-batch-size|100||Maximum number of records to include into DB batch|
+|Convert Payload|convert-payload|false|true, false|When set to true, Map/Record/Array/Choice fields will be converted to JSON strings. Otherwise processor will throw exception, if Map/Record/Array/Choice fields are present in the input Record. By default is set to false.|
 
 ### PostgreSQLBulkLoader
 
 The processor supports copying from stdin using the incoming content of the Flow File or a file accessible by path.
 It is also possible to copy from DB to FlowFile content.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Connection Pooling Service | dbcp-service |  |  | Database Connection Pooling Service to use for connecting to target Database. |
-| SQL Query | sql-query |  |  | SQL query to execute. Copy command from stdin/to stdout. |
-| File Path | file-path |  |  | Path to CSV file in file system. |
-| Buffer Size | buffer-size |  |  | Number of characters to buffer and push over network to server at once. |
-| Copy Mode | copy-mode | to | To, From | Provides a selection of copy mode (from stdin/to stdout). |
-| Read From | read-from | file-system | File System, Content | Provides a selection of data to copy. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Connection Pooling Service|dbcp-service|||Database Connection Pooling Service to use for connecting to target Database.|
+|SQL Query|sql-query|||SQL query to execute. Copy command from stdin/to stdout.|
+|File Path|file-path|||Path to CSV file in file system.|
+|Buffer Size|buffer-size|||Number of characters to buffer and push over network to server at once.|
+|Copy Mode|copy-mode|to|To, From|Provides a selection of copy mode (from stdin/to stdout).|
+|Read From|read-from|file-system|File System, Content|Provides a selection of data to copy.|
 <!-- End of additional processors properties description. DO NOT REMOVE. -->
 
 ## Additional controller services
@@ -202,14 +202,14 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 <!-- Table for additional controller services. DO NOT REMOVE. -->
 
-| Controller Service  | NAR                 | Description        |
-|----------------------|--------------------|--------------------|
-| RedisBulkDistributedMapCacheClientService | qubership-nifi-bulk-redis-nar | Provides a Redis-based distributed map cache client with bulk operation support. This service enables efficient batch operations on Redis cache, including bulk get-and-put-if-absent and bulk remove operations. It uses Lua scripting for atomic bulk operations and supports configurable TTL (time-to-live) for cached entries. The service is particularly useful for high-performance scenarios requiring atomic bulk cache operations across multiple NiFi instances. |
-| OraclePreparedStatementWithArrayProvider | qubership-service-nar | Provides a prepared statement service. |
-| PostgresPreparedStatementWithArrayProvider | qubership-service-nar | Provides a prepared statement service. |
-| JsonContentValidator | qubership-service-nar | Provides validate method to check the JSON against a given schema. |
-| QubershipPrometheusRecordSink | qubership-service-nar | A Record Sink service that exposes metrics to Prometheus via an embedded HTTP server on a configurable port. Collects metrics from incoming records by treating string fields as labels, numeric fields as gauges, and nested records (with 'type' and 'value' fields) as counters or distribution summaries. |
-| HttpLookupService | qubership-nifi-lookup-service-nar | Sends HTTP GET request with specified URL and headers (set up via dynamic PROPERTY_DESCRIPTORS) to look up values. If the response status code is 2xx, the response body is parsed with Record Reader and returned as array of records. Otherwise (status code other than 2xx), the controller service throws exception and logs the response body. |
+|Controller Service|NAR|Description|
+|---|---|---|
+|RedisBulkDistributedMapCacheClientService|qubership-nifi-bulk-redis-nar|Provides a Redis-based distributed map cache client with bulk operation support. This service enables efficient batch operations on Redis cache, including bulk get-and-put-if-absent and bulk remove operations. It uses Lua scripting for atomic bulk operations and supports configurable TTL (time-to-live) for cached entries. The service is particularly useful for high-performance scenarios requiring atomic bulk cache operations across multiple NiFi instances.|
+|OraclePreparedStatementWithArrayProvider|qubership-service-nar|Provides a prepared statement service.|
+|PostgresPreparedStatementWithArrayProvider|qubership-service-nar|Provides a prepared statement service.|
+|JsonContentValidator|qubership-service-nar|Provides validate method to check the JSON against a given schema.|
+|QubershipPrometheusRecordSink|qubership-service-nar|A Record Sink service that exposes metrics to Prometheus via an embedded HTTP server on a configurable port. Collects metrics from incoming records by treating string fields as labels, numeric fields as gauges, and nested records (with 'type' and 'value' fields) as counters or distribution summaries.|
+|HttpLookupService|qubership-nifi-lookup-service-nar|Sends HTTP GET request with specified URL and headers (set up via dynamic PROPERTY_DESCRIPTORS) to look up values. If the response status code is 2xx, the response body is parsed with Record Reader and returned as array of records. Otherwise (status code other than 2xx), the controller service throws exception and logs the response body.|
 
 ## Additional controller services properties description
 
@@ -223,37 +223,37 @@ and bulk remove operations. It uses Lua scripting for atomic bulk operations and
 TTL (time-to-live) for cached entries. The service is particularly useful for high-performance scenarios
 requiring atomic bulk cache operations across multiple NiFi instances.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Redis Connection Pool | redis-connection-pool |  |  | A service that provides connections to Redis. |
-| TTL | redis-cache-ttl | 0 secs |  | Indicates how long the data should exist in Redis.Setting '0 secs' would mean the data would exist forever |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Redis Connection Pool|redis-connection-pool|||A service that provides connections to Redis.|
+|TTL|redis-cache-ttl|0 secs||Indicates how long the data should exist in Redis.Setting '0 secs' would mean the data would exist forever|
 
 ### OraclePreparedStatementWithArrayProvider
 
 Provides a prepared statement service.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Schema Name | dbSchema |  |  | Owner of the array type |
-| Char Array Type | array-type | ARRAYOFSTRINGS |  | Character-based array type. |
-| Numeric Array Type | num-array-type | ARRAYOFNUMBERS |  | Numeric array type. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Schema Name|dbSchema|||Owner of the array type|
+|Char Array Type|array-type|ARRAYOFSTRINGS||Character-based array type.|
+|Numeric Array Type|num-array-type|ARRAYOFNUMBERS||Numeric array type.|
 
 ### PostgresPreparedStatementWithArrayProvider
 
 Provides a prepared statement service.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Char Array Type | array-type | text |  | Character array base type. |
-| Numeric Array Type | numeric-array-type | numeric |  | Numeric array base type. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Char Array Type|array-type|text||Character array base type.|
+|Numeric Array Type|numeric-array-type|numeric||Numeric array base type.|
 
 ### JsonContentValidator
 
 Provides validate method to check the JSON against a given schema.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Schema | schema |  |  | Validation JSON Schema. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Schema|schema|||Validation JSON Schema.|
 
 ### QubershipPrometheusRecordSink
 
@@ -262,11 +262,11 @@ on a configurable port. Collects metrics from incoming records by treating strin
 numeric fields as gauges, and nested records (with 'type' and 'value' fields)
 as counters or distribution summaries.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Prometheus Metrics Endpoint Port | prometheus-sink-metrics-endpoint-port | 9092 |  | The Port where prometheus metrics can be scraped from. |
-| Instance ID | prometheus-sink-instance-id | ${hostname(true)}_${NAMESPACE} |  | Identifier of the NiFi instance to be included in the metrics as a label. |
-| Clear Metrics on Disable | prometheus-sink-clear-metrics | No | Yes, No | If set to Yes, all metrics stored in the controller service are cleared, when the controller service is disabled. By default, metrics are not cleared. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Prometheus Metrics Endpoint Port|prometheus-sink-metrics-endpoint-port|9092||The Port where prometheus metrics can be scraped from.|
+|Instance ID|prometheus-sink-instance-id|\${hostname(true)}_\${NAMESPACE}||Identifier of the NiFi instance to be included in the metrics as a label.|
+|Clear Metrics on Disable|prometheus-sink-clear-metrics|No|Yes, No|If set to Yes, all metrics stored in the controller service are cleared, when the controller service is disabled. By default, metrics are not cleared.|
 
 ### HttpLookupService
 
@@ -274,12 +274,12 @@ Sends HTTP GET request with specified URL and headers (set up via dynamic PROPER
 If the response status code is 2xx, the response body is parsed with Record Reader and returned as array of records.
 Otherwise (status code other than 2xx), the controller service throws exception and logs the response body.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| URL | http-lookup-url |  |  | The URL to send request to. Expression language is supported and evaluated against both the lookup key-value pairs and FlowFile attributes. |
-| Record Reader | http-lookup-record-reader |  |  | The record reader to use for loading response body and handling it as a record set. |
-| Connection Timeout | http-lookup-connection-timeout | 5 secs |  | Max wait time for connection to remote service. |
-| Read Timeout | http-lookup-read-timeout | 15 secs |  | Max wait time for response from remote service. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|URL|http-lookup-url|||The URL to send request to. Expression language is supported and evaluated against both the lookup key-value pairs and FlowFile attributes.|
+|Record Reader|http-lookup-record-reader|||The record reader to use for loading response body and handling it as a record set.|
+|Connection Timeout|http-lookup-connection-timeout|5 secs||Max wait time for connection to remote service.|
+|Read Timeout|http-lookup-read-timeout|15 secs||Max wait time for response from remote service.|
 <!-- End of additional controller services description. DO NOT REMOVE. -->
 
 ## Additional reporting tasks
@@ -290,11 +290,11 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 <!-- Table for additional reporting tasks. DO NOT REMOVE. -->
 
-| Reporting Task  | NAR                 | Description        |
-|----------------------|--------------------|--------------------|
-| ComponentMetricsReportingTask | migration-nifi-processors-open | Sends components (Processors, Connections) metrics to InfluxDB. |
-| CommonMetricsReportingTask | migration-nifi-processors-open | Sends Nifi metrics to InfluxDB. |
-| ComponentPrometheusReportingTask | migration-nifi-processors-open | Sends components (Processors, Connections) metrics to Prometheus. |
+|Reporting Task|NAR|Description|
+|---|---|---|
+|ComponentMetricsReportingTask|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to InfluxDB.|
+|CommonMetricsReportingTask|migration-nifi-processors-open|Sends Nifi metrics to InfluxDB.|
+|ComponentPrometheusReportingTask|migration-nifi-processors-open|Sends components (Processors, Connections) metrics to Prometheus.|
 
 ## Additional reporting tasks properties description
 
@@ -304,45 +304,45 @@ More information on their usage is available in Help (`Global Menu` -> `Help`) w
 
 Sends components (Processors, Connections) metrics to InfluxDB.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Name | influxdb-dbname | monitoring_server |  | InfluxDB database |
-| InfluxDB URL | influxdb-url | `http://localhost:8086` |  | InfluxDB URL to connect to. For example, `http://influxdb:8086` |
-| Connection timeout | Connection timeout | 0 seconds |  | The maximum time for establishing connection to the InfluxDB |
-| Username | influxdb-username |  |  | Username for accessing InfluxDB |
-| Password | influxdb-password |  |  | Password for accessing InfluxDB |
-| Character Set | influxdb-charset | UTF-8 |  | Specifies the character set of the document data. |
-| Consistency Level | influxdb-consistency-level | ONE | One, Any, All, Quorum | InfluxDB consistency level |
-| Retention Policy | influxdb-retention-policy | monitor |  | Retention policy for the saving the records |
-| Max size of records | influxdb-max-records-size | 1 MB |  | Maximum size of records allowed to be posted in one batch |
-| Processor time threshold | processor-time-threshold | 150 sec |  | Minimal processing time for processor to be included in monitoring.Limits data volume collected in InfluxDB. |
-| Connection queue threshold | connection-queue-threshold | 80 |  | Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in InfluxDB. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Name|influxdb-dbname|monitoring_server||InfluxDB database|
+|InfluxDB URL|influxdb-url|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
+|Connection timeout|Connection timeout|0 seconds||The maximum time for establishing connection to the InfluxDB|
+|Username|influxdb-username|||Username for accessing InfluxDB|
+|Password|influxdb-password|||Password for accessing InfluxDB|
+|Character Set|influxdb-charset|UTF-8||Specifies the character set of the document data.|
+|Consistency Level|influxdb-consistency-level|ONE|One, Any, All, Quorum|InfluxDB consistency level|
+|Retention Policy|influxdb-retention-policy|monitor||Retention policy for the saving the records|
+|Max size of records|influxdb-max-records-size|1 MB||Maximum size of records allowed to be posted in one batch|
+|Processor time threshold|processor-time-threshold|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in InfluxDB.|
+|Connection queue threshold|connection-queue-threshold|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in InfluxDB.|
 
 ### CommonMetricsReportingTask
 
 Sends Nifi metrics to InfluxDB.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Database Name | influxdb-dbname | monitoring_server |  | InfluxDB database |
-| InfluxDB URL | influxdb-url | `http://localhost:8086` |  | InfluxDB URL to connect to. For example, `http://influxdb:8086` |
-| Connection timeout | Connection timeout | 0 seconds |  | The maximum time for establishing connection to the InfluxDB |
-| Username | influxdb-username |  |  | Username for accessing InfluxDB |
-| Password | influxdb-password |  |  | Password for accessing InfluxDB |
-| Character Set | influxdb-charset | UTF-8 |  | Specifies the character set of the document data. |
-| Consistency Level | influxdb-consistency-level | ONE | One, Any, All, Quorum | InfluxDB consistency level |
-| Retention Policy | influxdb-retention-policy | monitor |  | Retention policy for the saving the records |
-| Max size of records | influxdb-max-records-size | 1 MB |  | Maximum size of records allowed to be posted in one batch |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Database Name|influxdb-dbname|monitoring_server||InfluxDB database|
+|InfluxDB URL|influxdb-url|`http://localhost:8086`||InfluxDB URL to connect to. For example, `http://influxdb:8086`|
+|Connection timeout|Connection timeout|0 seconds||The maximum time for establishing connection to the InfluxDB|
+|Username|influxdb-username|||Username for accessing InfluxDB|
+|Password|influxdb-password|||Password for accessing InfluxDB|
+|Character Set|influxdb-charset|UTF-8||Specifies the character set of the document data.|
+|Consistency Level|influxdb-consistency-level|ONE|One, Any, All, Quorum|InfluxDB consistency level|
+|Retention Policy|influxdb-retention-policy|monitor||Retention policy for the saving the records|
+|Max size of records|influxdb-max-records-size|1 MB||Maximum size of records allowed to be posted in one batch|
 
 ### ComponentPrometheusReportingTask
 
 Sends components (Processors, Connections) metrics to Prometheus.
 
-| Display Name                      | API Name            | Default Value      | Allowable Values   | Description        |
-|-----------------------------------|---------------------|--------------------|--------------------|--------------------|
-| Server Port | port | 9192 |  | The Port where prometheus metrics can be accessed. |
-| Meter Registry Provider | meter-registry-provider |  |  | Identifier of Controller Services, which is used to obtain the Meter Registry. |
-| Processor time threshold | processor-time-threshold | 150 sec |  | Minimal processing time for processor to be included in monitoring.Limits data volume collected in Prometheus. |
-| Connection queue threshold | connection-queue-threshold | 80 |  | Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in Prometheus. |
-| Process group level threshold | pg-level-threshold | 2 |  | Maximum depth of process group to report in monitoring.Limits data volume collected in Prometheus. |
+|Display Name|API Name|Default Value|Allowable Values|Description|
+|---|---|---|---|---|
+|Server Port|port|9192||The Port where prometheus metrics can be accessed.|
+|Meter Registry Provider|meter-registry-provider|||Identifier of Controller Services, which is used to obtain the Meter Registry.|
+|Processor time threshold|processor-time-threshold|150 sec||Minimal processing time for processor to be included in monitoring.Limits data volume collected in Prometheus.|
+|Connection queue threshold|connection-queue-threshold|80||Minimal connection usage % relative to backPressureObjectThreshold.Limits data volume collected in Prometheus.|
+|Process group level threshold|pg-level-threshold|2||Maximum depth of process group to report in monitoring.Limits data volume collected in Prometheus.|
 <!-- End of additional reporting tasks description. DO NOT REMOVE. -->

--- a/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/processors/QueryIdsAndFetchTableToJson.java
+++ b/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/processors/QueryIdsAndFetchTableToJson.java
@@ -18,6 +18,7 @@ package org.qubership.nifi.processors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.qubership.nifi.NiFiUtils;
 import org.qubership.nifi.service.PreparedStatementProvider;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -53,6 +54,11 @@ import java.util.UUID;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
 @Tags({"JSON", "DB"})
+@CapabilityDescription("Fetches data from source DB into JSON using query (Custom Query) and\n"
+        + " ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then\n"
+        + " for each batch of ids, main query is executed to get data and transform it to JSON. Data is\n"
+        + "collected until Batch Size is reached, then it is loaded into FlowFile.\n"
+        + " Data collection continues until all rows are processed.")
 @WritesAttributes({
         @WritesAttribute(attribute = "mime.type", description = "Sets mime.type = application/json"),
         @WritesAttribute(attribute = "fetch.id", description = "Sets to UUID"),
@@ -82,10 +88,11 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
             .build();
 
     /**
-     * Mapping DB Connection property descriptor.
+     * IDs DB Connection property descriptor.
      */
     public static final PropertyDescriptor IDS_DBCP_SERVICE = new PropertyDescriptor.Builder()
             .name("Ids Database Connection Pooling Service")
+            .displayName("IDs Database Connection Pooling Service")
             .description("The Controller Service that is used to obtain a connection to the mapping database.")
             .required(true)
             .identifiesControllerService(DBCPService.class)
@@ -116,12 +123,12 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
             .build();
 
     /**
-     * Ids batch size property descriptor.
+     * IDs batch size property descriptor.
      */
     public static final PropertyDescriptor IDS_BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("ids-batch-size")
-            .displayName("Ids Batch Size")
-            .description("The maximum number of rows in table from ids database from the result.")
+            .displayName("IDs Batch Size")
+            .description("The maximum number of rows in table from IDs database from the result.")
             .defaultValue("1")
             .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -142,11 +149,11 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
             .build();
 
     /**
-     * Ids fetch size property descriptor.
+     * IDs fetch size property descriptor.
      */
     public static final PropertyDescriptor IDS_FETCH_SIZE = new PropertyDescriptor.Builder()
             .name("ids-fetch-size")
-            .displayName("Ids Fetch Size")
+            .displayName("IDs Fetch Size")
             .description("The number of result rows to be fetched from the result set at a time. "
                     + "This is a hint to the database driver and may not be "
                     + "honored and/or exact. If the value specified is zero, then the hint is ignored.")
@@ -168,12 +175,12 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
             .build();
 
     /**
-     * Ids custom query property descriptor.
+     * IDs custom query property descriptor.
      */
     public static final PropertyDescriptor IDS_CUSTOM_QUERY = new PropertyDescriptor.Builder()
             .name("ids-custom-query")
-            .displayName("Ids Custom Query")
-            .description("Custom request to get a list of id.")
+            .displayName("IDs Custom Query")
+            .description("Custom request to get a list of IDs.")
             .defaultValue("${mapping.db.query}")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -194,11 +201,11 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
             .build();
 
     /**
-     * Ids write by batch property descriptor.
+     * IDs write by batch property descriptor.
      */
     public static final PropertyDescriptor IDS_WRITE_BY_BATCH = new PropertyDescriptor.Builder()
             .name("ids-write-by-batch")
-            .displayName("Ids Write By Batch")
+            .displayName("IDs Write By Batch")
             .description("Write a type that corresponds to the behavior of appearing FlowFiles in the queue.")
             .required(false)
             .allowableValues("true", "false")

--- a/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/processors/QueryIdsAndFetchTableToJson.java
+++ b/qubership-bundle/qubership-nifi-processors-impl/src/main/java/org/qubership/nifi/processors/QueryIdsAndFetchTableToJson.java
@@ -55,8 +55,8 @@ import java.util.UUID;
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
 @Tags({"JSON", "DB"})
 @CapabilityDescription("Fetches data from source DB into JSON using query (Custom Query) and\n"
-        + " ids obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then\n"
-        + " for each batch of ids, main query is executed to get data and transform it to JSON. Data is\n"
+        + " IDs obtained from IDs DB with query (IDs Custom Query). IDs query is executed first, then\n"
+        + " for each batch of IDs, main query is executed to get data and transform it to JSON. Data is\n"
         + "collected until Batch Size is reached, then it is loaded into FlowFile.\n"
         + " Data collection continues until all rows are processed.")
 @WritesAttributes({
@@ -93,7 +93,7 @@ public class QueryIdsAndFetchTableToJson extends AbstractProcessor {
     public static final PropertyDescriptor IDS_DBCP_SERVICE = new PropertyDescriptor.Builder()
             .name("Ids Database Connection Pooling Service")
             .displayName("IDs Database Connection Pooling Service")
-            .description("The Controller Service that is used to obtain a connection to the mapping database.")
+            .description("The Controller Service that is used to obtain a connection to the IDs database.")
             .required(true)
             .identifiesControllerService(DBCPService.class)
             .build();

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDescriptorEntity.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDescriptorEntity.java
@@ -203,6 +203,6 @@ public class PropertyDescriptorEntity {
             return str;
         }
 
-        return str.replaceAll("\\$", "\\\\\\$");
+        return str.replace("$", "\\$");
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDescriptorEntity.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDescriptorEntity.java
@@ -78,7 +78,7 @@ public class PropertyDescriptorEntity {
         if (defaultValue == null || defaultValue.isEmpty()) {
             return "";
         }
-        return escapeHttpLinks(defaultValue);
+        return escapeSpecialCharacters(escapeHttpLinks(defaultValue));
     }
 
     /**
@@ -97,7 +97,7 @@ public class PropertyDescriptorEntity {
         if (description == null || description.isEmpty()) {
             return "";
         }
-        return escapeHttpLinks(description);
+        return escapeSpecialCharacters(escapeHttpLinks(description));
     }
 
     /**
@@ -183,5 +183,26 @@ public class PropertyDescriptorEntity {
         }
 
         return str.replaceAll(HTTP_REGEX, "`$1`");
+    }
+
+
+    /**
+     * Escapes $ sign in a string by adding \.
+     *
+     * @param str the input string to process
+     * @return string with escaped $ sign, or the original string
+     *  *         if it is {@code null}, empty, or does not contain $
+     */
+
+    public String escapeSpecialCharacters(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+
+        if (!str.contains("$")) {
+            return str;
+        }
+
+        return str.replaceAll("\\$", "\\\\\\$");
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDocumentation.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/PropertyDocumentation.java
@@ -230,37 +230,35 @@ public class PropertyDocumentation extends AbstractMojo {
                 Class<? extends Processor> processorClass = processorInstance.getClass();
                 ProcessorInitializationContext initializationContext = new MockProcessorInitializationContext();
                 processorInstance.initialize(initializationContext);
-                CapabilityDescription capabilityDescriptionAnnotationProc =
+                CapabilityDescription capabilityDescription =
                         processorClass.getAnnotation(CapabilityDescription.class);
                 List<PropertyDescriptor> propertyDescriptors = processorInstance.getPropertyDescriptors();
-                if (capabilityDescriptionAnnotationProc != null) {
-                    String processorName = processorClass.getSimpleName();
-                    String descriptionValue = capabilityDescriptionAnnotationProc.value();
-                    List<PropertyDescriptorEntity> componentProperties =
-                            generateComponentPropertiesList(propertyDescriptors, descriptionValue);
-                    customComponentList.add(new CustomComponentEntity(processorName, PROCESSOR, project.getArtifactId(),
-                            descriptionValue, componentProperties));
-                }
+                String processorName = processorClass.getSimpleName();
+                String descriptionValue = capabilityDescription != null
+                        ? capabilityDescription.value() : "";
+                List<PropertyDescriptorEntity> componentProperties =
+                        generateComponentPropertiesList(propertyDescriptors, descriptionValue);
+                customComponentList.add(new CustomComponentEntity(processorName, PROCESSOR, project.getArtifactId(),
+                        descriptionValue, componentProperties));
             }
 
             ServiceLoader<ControllerService> controllerServiceServiceLoader =
                     ServiceLoader.load(ControllerService.class, componentClassLoader);
             for (ControllerService controllerServiceInstance : controllerServiceServiceLoader) {
                 Class<? extends ControllerService> controllerServiceClass = controllerServiceInstance.getClass();
-                CapabilityDescription capabilityDescriptionAnnotationCS =
+                CapabilityDescription capabilityDescription =
                         controllerServiceClass.getAnnotation(CapabilityDescription.class);
                 ControllerServiceInitializationContext controllerServiceInitializationContext =
                         new MockControllerServiceInitializationContext();
                 controllerServiceInstance.initialize(controllerServiceInitializationContext);
                 List<PropertyDescriptor> propertyDescriptors = controllerServiceInstance.getPropertyDescriptors();
-                if (capabilityDescriptionAnnotationCS != null) {
-                    String controllerServiceName = controllerServiceClass.getSimpleName();
-                    String descriptionValue = capabilityDescriptionAnnotationCS.value();
-                    List<PropertyDescriptorEntity> componentProperties =
-                            generateComponentPropertiesList(propertyDescriptors, descriptionValue);
-                    customComponentList.add(new CustomComponentEntity(controllerServiceName, CONTROLLER_SERVICE,
-                            project.getArtifactId(), descriptionValue, componentProperties));
-                }
+                String controllerServiceName = controllerServiceClass.getSimpleName();
+                String descriptionValue = capabilityDescription != null
+                        ? capabilityDescription.value() : "";
+                List<PropertyDescriptorEntity> componentProperties =
+                        generateComponentPropertiesList(propertyDescriptors, descriptionValue);
+                customComponentList.add(new CustomComponentEntity(controllerServiceName, CONTROLLER_SERVICE,
+                        project.getArtifactId(), descriptionValue, componentProperties));
             }
 
             ServiceLoader<ReportingTask> reportingTaskServiceLoader =
@@ -270,17 +268,16 @@ public class PropertyDocumentation extends AbstractMojo {
                 ReportingInitializationContext reportingInitializationContext =
                         new MockReportingInitializationContext();
                 reportingTaskInstance.initialize(reportingInitializationContext);
-                CapabilityDescription capabilityDescriptionAnnotationRT = reportingTaskClass
+                CapabilityDescription capabilityDescription = reportingTaskClass
                         .getAnnotation(CapabilityDescription.class);
                 List<PropertyDescriptor> propertyDescriptors = reportingTaskInstance.getPropertyDescriptors();
-                if (capabilityDescriptionAnnotationRT != null) {
-                    String reportingTaskName = reportingTaskClass.getSimpleName();
-                    String descriptionValue = capabilityDescriptionAnnotationRT.value();
-                    List<PropertyDescriptorEntity> componentProperties =
-                            generateComponentPropertiesList(propertyDescriptors, descriptionValue);
-                    customComponentList.add(new CustomComponentEntity(reportingTaskName, REPORTING_TASK,
-                            project.getArtifactId(), descriptionValue, componentProperties));
-                }
+                String reportingTaskName = reportingTaskClass.getSimpleName();
+                String descriptionValue = capabilityDescription != null
+                        ? capabilityDescription.value() : "";
+                List<PropertyDescriptorEntity> componentProperties =
+                        generateComponentPropertiesList(propertyDescriptors, descriptionValue);
+                customComponentList.add(new CustomComponentEntity(reportingTaskName, REPORTING_TASK,
+                        project.getArtifactId(), descriptionValue, componentProperties));
             }
 
             List<CustomComponentEntity> processorEntities = customComponentList.stream()

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/utils/MarkdownUtils.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/utils/MarkdownUtils.java
@@ -170,9 +170,9 @@ public class MarkdownUtils {
         List<String> newTableRows = new ArrayList<>();
         if (!customComponentList.isEmpty()) {
             for (CustomComponentEntity customComponentEntity : customComponentList) {
-                String tableRow = "|"
+                String tableRow = "|`"
                         + customComponentEntity.getComponentName()
-                        + "|"
+                        + "`|"
                         + customComponentEntity.getComponentNar()
                         + "|"
                         + customComponentEntity.getComponentDescription().replaceAll("\\r?\\n|\\r", "")
@@ -296,7 +296,7 @@ public class MarkdownUtils {
                                     ? entity.getAllowableValuesAsString() : "";
                             String description = entity.getDescriptionAsString() != null
                                     ? entity.getDescriptionAsString() : "";
-                            descriptionLines.add("|" + displayName + "|" + apiName + "|" + defaultValue + "|"
+                            descriptionLines.add("|" + displayName + "|`" + apiName + "`|" + defaultValue + "|"
                                     + allowableValuesStr + "|" + description + "|");
                         } else {
                             getLog().error("Found null entity in list for component '"

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/utils/MarkdownUtils.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/main/java/org/qubership/nifi/utils/MarkdownUtils.java
@@ -38,17 +38,16 @@ public class MarkdownUtils {
             "<!-- End of additional reporting tasks description. DO NOT REMOVE. -->";
 
 
-    private static final String HEADER_BASE = " | NAR                 | Description        |";
-    private static final String HEADER_PROCESSORS = "| Processor " + HEADER_BASE;
-    private static final String HEADER_CONTROLLER_SERVICES = "| Controller Service " + HEADER_BASE;
-    private static final String HEADER_REPORTING_TASKS = "| Reporting Task " + HEADER_BASE;
-    private static final String TITLE_SEPARATOR = "|----------------------|--------------------|--------------------|";
+    private static final String HEADER_BASE = "|NAR|Description|";
+    private static final String HEADER_PROCESSORS = "|Processor" + HEADER_BASE;
+    private static final String HEADER_CONTROLLER_SERVICES = "|Controller Service" + HEADER_BASE;
+    private static final String HEADER_REPORTING_TASKS = "|Reporting Task" + HEADER_BASE;
+    private static final String TITLE_SEPARATOR = "|---|---|---|";
 
-    private static final String PROPERTIES_DESCRIPTION_HEADER = "| Display Name                      | API Name        "
-            + "    | Default Value      | Allowable Values   | Description        |";
+    private static final String PROPERTIES_DESCRIPTION_HEADER = "|Display Name|API Name"
+            + "|Default Value|Allowable Values|Description|";
 
-    private static final String PROPERTIES_DESCRIPTION_TITLE_SEPARATOR = "|-----------------------------------|------"
-            + "---------------|--------------------|--------------------|--------------------|";
+    private static final String PROPERTIES_DESCRIPTION_TITLE_SEPARATOR = "|---|---|---|---|---|";
 
     private static final int DEFAULT_HEADER_LEVEL = 3;
     private static final int MIN_HEADER_LEVEL = 1;
@@ -171,13 +170,13 @@ public class MarkdownUtils {
         List<String> newTableRows = new ArrayList<>();
         if (!customComponentList.isEmpty()) {
             for (CustomComponentEntity customComponentEntity : customComponentList) {
-                String tableRow = "| "
+                String tableRow = "|"
                         + customComponentEntity.getComponentName()
-                        + " | "
+                        + "|"
                         + customComponentEntity.getComponentNar()
-                        + " | "
+                        + "|"
                         + customComponentEntity.getComponentDescription().replaceAll("\\r?\\n|\\r", "")
-                        + " |";
+                        + "|";
                 newTableRows.add(tableRow);
             }
         }
@@ -297,8 +296,8 @@ public class MarkdownUtils {
                                     ? entity.getAllowableValuesAsString() : "";
                             String description = entity.getDescriptionAsString() != null
                                     ? entity.getDescriptionAsString() : "";
-                            descriptionLines.add("| " + displayName + " | " + apiName + " | " + defaultValue + " | "
-                                    + allowableValuesStr + " | " + description + " |");
+                            descriptionLines.add("|" + displayName + "|" + apiName + "|" + defaultValue + "|"
+                                    + allowableValuesStr + "|" + description + "|");
                         } else {
                             getLog().error("Found null entity in list for component '"
                                     + componentName + "'");

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/test/java/org/qubership/nifi/PropertyDocumentationGenerateDocumentationTest.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/test/java/org/qubership/nifi/PropertyDocumentationGenerateDocumentationTest.java
@@ -170,15 +170,15 @@ class PropertyDocumentationGenerateDocumentationTest {
                 "Output should contain the property display name");
     }
 
-    /** Verifies processors without {@code @CapabilityDescription} are excluded from the output. */
+    /** Verifies processors without {@code @CapabilityDescription} are included in the output. */
     @Test
-    void testGenerateDocumentationIgnoresProcessorWithoutCapabilityDescription() throws Exception {
+    void testGenerateDocumentationContainsProcessorWithoutCapabilityDescription() throws Exception {
         mockForClass(ContentValidatorProcessor.class);
         mojo.execute();
 
         String output = Files.readString(outputFile);
-        assertFalse(output.contains("BulkDistributedMapCacheProcessor"),
-                "Output should not document BulkDistributedMapCacheProcessor (no @CapabilityDescription)");
+        assertTrue(output.contains("BulkDistributedMapCacheProcessor"),
+                "Output should document BulkDistributedMapCacheProcessor (no @CapabilityDescription)");
     }
 
     /** Verifies controller services with {@code @CapabilityDescription} are included in the output. */

--- a/qubership-nifi-tools/qubership-nifi-docs-generator/src/test/java/org/qubership/nifi/utils/MarkdownUtilsTest.java
+++ b/qubership-nifi-tools/qubership-nifi-docs-generator/src/test/java/org/qubership/nifi/utils/MarkdownUtilsTest.java
@@ -79,8 +79,8 @@ class MarkdownUtilsTest {
         utils.generateTable(Collections.singletonList(entity), ComponentType.PROCESSOR);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-        assertTrue(result.contains("| Processor "), "Should contain processor header");
+        String result = Files.readString(file);
+        assertTrue(result.contains("|Processor"), "Should contain processor header");
         assertTrue(result.contains("MyProcessor"), "Should contain processor name");
         assertTrue(result.contains("my-nar"), "Should contain nar name");
     }
@@ -93,9 +93,9 @@ class MarkdownUtilsTest {
                 + "\n"
                 + "<!-- Table for additional processors. DO NOT REMOVE. -->\n"
                 + "\n"
-                + "| Processor  | NAR                 | Description        |\n"
-                + "|----------------------|--------------------|--------------------|\n"
-                + "| ExistingProcessor | existing-nar | Existing description |\n"
+                + "|Processor|NAR|Description|\n"
+                + "|---|---|---|\n"
+                + "|ExistingProcessor|existing-nar|Existing description|\n"
                 + "\n"
                 + "<!-- Additional processors properties description. DO NOT REMOVE. -->\n"
                 + "<!-- End of additional processors properties description. DO NOT REMOVE. -->\n"
@@ -115,7 +115,7 @@ class MarkdownUtilsTest {
         utils.generateTable(Collections.singletonList(entity), ComponentType.PROCESSOR);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        String result = Files.readString(file);
         assertTrue(result.contains("ExistingProcessor"), "Should still contain existing processor");
         assertTrue(result.contains("NewProcessor"), "Should contain new processor");
     }
@@ -132,8 +132,8 @@ class MarkdownUtilsTest {
         utils.generateTable(Collections.singletonList(entity), ComponentType.CONTROLLER_SERVICE);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-        assertTrue(result.contains("| Controller Service "), "Should contain controller service header");
+        String result = Files.readString(file);
+        assertTrue(result.contains("|Controller Service"), "Should contain controller service header");
         assertTrue(result.contains("MyService"), "Should contain service name");
     }
 
@@ -149,8 +149,8 @@ class MarkdownUtilsTest {
         utils.generateTable(Collections.singletonList(entity), ComponentType.REPORTING_TASK);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-        assertTrue(result.contains("| Reporting Task "), "Should contain reporting task header");
+        String result = Files.readString(file);
+        assertTrue(result.contains("|Reporting Task"), "Should contain reporting task header");
         assertTrue(result.contains("MyTask"), "Should contain task name");
     }
 
@@ -164,9 +164,9 @@ class MarkdownUtilsTest {
         utils.generateTable(Collections.emptyList(), ComponentType.PROCESSOR);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-        assertTrue(result.contains("| Processor "), "Should contain processor header");
-        assertTrue(result.contains("|----------------------|"), "Should contain separator row");
+        String result = Files.readString(file);
+        assertTrue(result.contains("|Processor"), "Should contain processor header");
+        assertTrue(result.contains("|---|"), "Should contain separator row");
     }
 
     /** Verifies generatePropertyDescription() inserts component heading and property details. */
@@ -186,7 +186,7 @@ class MarkdownUtilsTest {
         utils.generatePropertyDescription(Collections.singletonList(entity), ComponentType.PROCESSOR);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        String result = Files.readString(file);
         assertTrue(result.contains("### MyProcessor"), "Should contain component heading");
         assertTrue(result.contains("My Property"), "Should contain property display name");
         assertTrue(result.contains("Component overall description"), "Should contain component description");
@@ -209,7 +209,7 @@ class MarkdownUtilsTest {
         utils.generatePropertyDescription(Collections.singletonList(entity), ComponentType.PROCESSOR);
         utils.writeToFile();
 
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        String result = Files.readString(file);
         assertTrue(result.contains("## MyProcessor"), "Should use level-2 heading");
         assertFalse(result.contains("### MyProcessor"), "Should not use default level-3 heading");
     }
@@ -227,7 +227,7 @@ class MarkdownUtilsTest {
         utils.writeToFile();
 
         // Re-read from disk to verify persistence
-        String result = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        String result = Files.readString(file);
         assertTrue(result.contains("PersistProcessor"), "Should contain written processor name");
     }
 


### PR DESCRIPTION
1. add processing of components with empty capability description in doc generator
2. change markdown table format to compact in doc generator
3. add capability description and fix property descriptions in QueryIdsAndFetchTableToJson processor