### PR TITLE
feat: add cs references markers and JSON mapping file for processors to comparison tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,5 @@ Controller services follow the same pattern with interface and implementation sp
 - The `docs/user-guide.md` is generated: edit `docs/template/user-guide-template.md` or
   `qubership-nifi-tools/qubership-nifi-docs-generator`.
 - The `docs/openapi/openapi.json` is generated: edit `qubership-nifi-tools/qubership-nifi-openapi-enricher` to change.
+- Use ASCII characters only in source code and documentation. Avoid Unicode punctuation such as em-dashes,
+  smart quotes, and arrows; use the ASCII equivalents (`-`, `->`, straight quotes) instead.

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/README.md
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/README.md
@@ -1,11 +1,13 @@
 # qubership-nifi-component-comparator-tool
 
 Command-line tool for comparing component properties from two different NiFi versions.
-The qubership-nifi-component-comparator-tool produces three files:
+The qubership-nifi-component-comparator-tool produces four files:
 
 - a CSV file containing detailed information about the comparison results.
 - a Markdown file containing detailed information about the comparison results.
-- a JSON file that can be used later when updating Controller Services and Reporting Task exports.
+- a JSON file (`NiFiTypeMapping.json`) used later when updating Controller Services and Reporting Task
+  exports.
+- a JSON file (`NiFiProcessorTypeMapping.json`) used later when updating Processor exports.
 
 ## Prerequisites
 
@@ -37,8 +39,21 @@ mvn exec:java \
 <outputPath>/
   NiFiComponentsDelta.csv
   NiFiTypeMapping.json
+  NiFiProcessorTypeMapping.json
   NiFiComponentsDelta.md
 ```
+
+## Type-mapping JSON files
+
+Two JSON files carry the rename and deletion mappings, split by component kind:
+
+- `NiFiTypeMapping.json` covers controller services and reporting tasks.
+- `NiFiProcessorTypeMapping.json` covers processors.
+
+Both share the same shape, `{ componentType: { oldApiName: newApiName | null } }`: a renamed property maps
+its old API name to the new one, and a deleted property maps its API name to `null`. Deletions are recorded
+only when the property is listed in the dictionary's `propertiesAllowedToDelete` section for its component
+type; renames are always recorded.
 
 ## Controller service references
 
@@ -47,10 +62,7 @@ Some properties hold a reference to a controller service rather than a literal v
 deleted, or added) that references a controller service and records the referenced controller-service
 interface type, such as `org.apache.nifi.dbcp.DBCPService`.
 
-In the CSV and Markdown outputs the marker is set for every renamed, deleted, and added reference. The
-JSON `controllerServiceReferences` section covers only renamed references, matching the JSON mapping,
-which records renamed and removed properties. Added references are excluded, and deleted references are
-skipped because they have no new API name to key by.
+The marker appears only in the CSV and Markdown outputs. The type-mapping JSON files do not carry it.
 
 A reference is detected from the property descriptor in one of two ways, depending on the export's NiFi
 version:
@@ -58,16 +70,12 @@ version:
 - `identifiesControllerService`: a string holding the interface type (NiFi 1.x exports).
 - `typeProvidedByValue.type`: the interface type nested in an object (NiFi 2.x exports).
 
-The marker appears in each output:
+The marker appears in two outputs:
 
 - **CSV**: a `Controller Service Reference` column holds the interface type, or is empty for plain
   properties.
 - **Markdown**: the per-component tables gain a `Controller Service Reference` column. The summary adds
   a `Controller service reference changes` metric and a `CS Refs` column in the per-type breakdown.
-- **JSON**: a sibling `controllerServiceReferences` section maps each component type to its
-  `{ newApiName: controllerServiceType }` entries, keyed by the new (target) API name. The existing rename
-  map is unchanged. As with renames, processor types are excluded, so the section is omitted when there are
-  no controller-service or reporting-task references.
 
 ## Running tests
 

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/README.md
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/README.md
@@ -40,6 +40,35 @@ mvn exec:java \
   NiFiComponentsDelta.md
 ```
 
+## Controller service references
+
+Some properties hold a reference to a controller service rather than a literal value, for example
+`Database Connection Pooling Service` in `ExecuteSQL`. The tool marks each changed property (renamed,
+deleted, or added) that references a controller service and records the referenced controller-service
+interface type, such as `org.apache.nifi.dbcp.DBCPService`.
+
+In the CSV and Markdown outputs the marker is set for every renamed, deleted, and added reference. The
+JSON `controllerServiceReferences` section covers only renamed references, matching the JSON mapping,
+which records renamed and removed properties. Added references are excluded, and deleted references are
+skipped because they have no new API name to key by.
+
+A reference is detected from the property descriptor in one of two ways, depending on the export's NiFi
+version:
+
+- `identifiesControllerService`: a string holding the interface type (NiFi 1.x exports).
+- `typeProvidedByValue.type`: the interface type nested in an object (NiFi 2.x exports).
+
+The marker appears in each output:
+
+- **CSV**: a `Controller Service Reference` column holds the interface type, or is empty for plain
+  properties.
+- **Markdown**: the per-component tables gain a `Controller Service Reference` column. The summary adds
+  a `Controller service reference changes` metric and a `CS Refs` column in the per-type breakdown.
+- **JSON**: a sibling `controllerServiceReferences` section maps each component type to its
+  `{ newApiName: controllerServiceType }` entries, keyed by the new (target) API name. The existing rename
+  map is unchanged. As with renames, processor types are excluded, so the section is omitted when there are
+  no controller-service or reporting-task references.
+
 ## Running tests
 
 Unit tests (no Docker required):

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/ComponentProperties.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/ComponentProperties.java
@@ -9,6 +9,7 @@ public class ComponentProperties {
     private final String displayName;
     private final String description;
     private Map<String, String> equivalentNameMappings;
+    private String controllerServiceType;
 
     /**
      * Constructor for class ComponentProperties.
@@ -49,6 +50,35 @@ public class ComponentProperties {
      */
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Sets the controller-service interface type that this property references,
+     * or {@code null} if the property does not reference a controller service.
+     *
+     * @param controllerServiceTypeValue fully qualified controller-service interface type
+     */
+    public void setControllerServiceType(String controllerServiceTypeValue) {
+        this.controllerServiceType = controllerServiceTypeValue;
+    }
+
+    /**
+     * Returns the controller-service interface type referenced by this property.
+     *
+     * @return the controller-service interface type, or null if the property
+     *         does not reference a controller service
+     */
+    public String getControllerServiceType() {
+        return controllerServiceType;
+    }
+
+    /**
+     * Indicates whether this property references a controller service.
+     *
+     * @return true if a controller-service interface type is set
+     */
+    public boolean referencesControllerService() {
+        return controllerServiceType != null;
     }
 
     /**

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/CsvReportGenerator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/CsvReportGenerator.java
@@ -22,7 +22,8 @@ public class CsvReportGenerator {
     private static final String[] CSV_HEADERS = {
             "Component Name", "Component Type", "Change Type",
             "Old Display Name", "New Display Name",
-            "Old Api Name", "New Api Name"
+            "Old Api Name", "New Api Name",
+            "Controller Service Reference"
     };
 
     private final Path outputDir;

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonComparator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonComparator.java
@@ -45,6 +45,7 @@ public class JsonComparator {
     private Map<String, Set<String>> allowedToDelete = new HashMap<>();
     private final List<String[]> csvRecords = new ArrayList<>();
     private final Map<String, Map<String, String>> typeToChangedProperties = new HashMap<>();
+    private final Map<String, Map<String, String>> typeToControllerServiceRefs = new HashMap<>();
     private final Map<String, String> typeToFolderMap = new HashMap<>();
 
     private boolean isLoaded = false;
@@ -131,6 +132,19 @@ public class JsonComparator {
     }
 
     /**
+     * Returns the controller-service references produced by {@link #compare()}.
+     * Only renamed properties that reference a controller service are included.
+     * Added properties are excluded because the JSON mapping records only renamed
+     * and removed properties, and deleted properties are skipped because they have
+     * no new API name to key by. The key is the new API name.
+     *
+     * @return unmodifiable map of componentType to (new API name -> controller-service type)
+     */
+    public Map<String, Map<String, String>> getTypeToControllerServiceRefs() {
+        return Collections.unmodifiableMap(typeToControllerServiceRefs);
+    }
+
+    /**
      * Returns the mapping of component type to subfolder name.
      *
      * @return unmodifiable map of componentType to subfolder
@@ -177,6 +191,7 @@ public class JsonComparator {
         allowedToDelete.clear();
         csvRecords.clear();
         typeToChangedProperties.clear();
+        typeToControllerServiceRefs.clear();
         typeToFolderMap.clear();
     }
 
@@ -364,6 +379,7 @@ public class JsonComparator {
 
             ComponentProperties cp = new ComponentProperties(apiName, displayName, description);
             cp.setEquivalentNameMappings(nameMappings);
+            cp.setControllerServiceType(extractControllerServiceType(prop));
             result.add(cp);
         });
 
@@ -391,18 +407,24 @@ public class JsonComparator {
 
             if (matchingTarget != null) {
                 if (!Objects.equals(sourceProp.getApiName(), matchingTarget.getApiName())) {
+                    String csType = matchingTarget.referencesControllerService()
+                            ? matchingTarget.getControllerServiceType()
+                            : sourceProp.getControllerServiceType();
                     csvRecords.add(createCsvRecord(fileName, componentFolder, "rename",
-                            sourceProp.getDisplayName(), matchingTarget.getDisplayName(),
-                            sourceProp.getApiName(), matchingTarget.getApiName()));
+                            new PropertyNames(sourceProp.getDisplayName(), matchingTarget.getDisplayName(),
+                                    sourceProp.getApiName(), matchingTarget.getApiName()), csType));
                     recordRename(componentType, sourceProp.getApiName(), matchingTarget.getApiName());
+                    recordControllerServiceRef(componentType, matchingTarget.getApiName(), csType);
                 }
             } else {
+                String csType = sourceProp.getControllerServiceType();
                 csvRecords.add(createCsvRecord(fileName, componentFolder, "deleted",
-                        sourceProp.getDisplayName(), "",
-                        sourceProp.getApiName(), ""));
+                        new PropertyNames(sourceProp.getDisplayName(), "",
+                                sourceProp.getApiName(), ""), csType));
                 if (isDeleteAllowed(componentType, sourceProp.getDisplayName())) {
                     recordDeleted(componentType, sourceProp.getApiName());
                 }
+                // Deleted properties are intentionally skipped: they have no new API name to key by.
             }
         }
     }
@@ -419,9 +441,12 @@ public class JsonComparator {
                             : srcProp.compareUniqueDisplayName(targetProp));
 
             if (!existsInSource) {
+                String csType = targetProp.getControllerServiceType();
                 csvRecords.add(createCsvRecord(fileName, componentFolder, "added",
-                        "", targetProp.getDisplayName(),
-                        "", targetProp.getApiName()));
+                        new PropertyNames("", targetProp.getDisplayName(),
+                                "", targetProp.getApiName()), csType));
+                // Added properties are intentionally skipped in the references map: the JSON
+                // mapping records only renamed and removed properties, not added ones.
             }
         }
     }
@@ -450,6 +475,40 @@ public class JsonComparator {
                 .put(apiName, null);
     }
 
+    private void recordControllerServiceRef(String componentType, String displayName, String csType) {
+        if (componentType == null || displayName == null || csType == null) {
+            return;
+        }
+        typeToControllerServiceRefs.computeIfAbsent(componentType, k -> new HashMap<>())
+                .put(displayName, csType);
+    }
+
+    /**
+     * Extracts the controller-service interface type referenced by a property descriptor.
+     * NiFi 1.x exports expose it as a textual {@code identifiesControllerService}, while
+     * NiFi 2.x exports expose it as {@code typeProvidedByValue.type}.
+     *
+     * @param prop the property-descriptor JSON node
+     * @return the controller-service interface type, or null if the property is not a reference
+     */
+    private String extractControllerServiceType(JsonNode prop) {
+        if (prop == null) {
+            return null;
+        }
+        JsonNode identifies = prop.get("identifiesControllerService");
+        if (identifies != null && identifies.isTextual()) {
+            return identifies.asText();
+        }
+        JsonNode providedByValue = prop.get("typeProvidedByValue");
+        if (providedByValue != null && providedByValue.isObject()) {
+            JsonNode typeNode = providedByValue.get("type");
+            if (typeNode != null && typeNode.isTextual()) {
+                return typeNode.asText();
+            }
+        }
+        return null;
+    }
+
     private String getShortTypeName(String fullTypeName) {
         if (fullTypeName == null || fullTypeName.isEmpty()) {
             return null;
@@ -460,17 +519,21 @@ public class JsonComparator {
                 : fullTypeName;
     }
 
+    private record PropertyNames(String displayNameOld, String displayNameNew,
+                                 String apiNameOld, String apiNameNew) {
+    }
+
     private String[] createCsvRecord(String filename, String componentType, String changeType,
-                                     String displayNameOld, String displayNameNew,
-                                     String apiNameOld, String apiNameNew) {
+                                     PropertyNames names, String controllerServiceRef) {
         return new String[]{
                 removeJsonExtension(filename),
                 componentType != null ? componentType : "",
                 changeType,
-                displayNameOld,
-                displayNameNew,
-                apiNameOld,
-                apiNameNew
+                names.displayNameOld(),
+                names.displayNameNew(),
+                names.apiNameOld(),
+                names.apiNameNew(),
+                controllerServiceRef != null ? controllerServiceRef : ""
         };
     }
 

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonComparator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonComparator.java
@@ -45,7 +45,6 @@ public class JsonComparator {
     private Map<String, Set<String>> allowedToDelete = new HashMap<>();
     private final List<String[]> csvRecords = new ArrayList<>();
     private final Map<String, Map<String, String>> typeToChangedProperties = new HashMap<>();
-    private final Map<String, Map<String, String>> typeToControllerServiceRefs = new HashMap<>();
     private final Map<String, String> typeToFolderMap = new HashMap<>();
 
     private boolean isLoaded = false;
@@ -132,19 +131,6 @@ public class JsonComparator {
     }
 
     /**
-     * Returns the controller-service references produced by {@link #compare()}.
-     * Only renamed properties that reference a controller service are included.
-     * Added properties are excluded because the JSON mapping records only renamed
-     * and removed properties, and deleted properties are skipped because they have
-     * no new API name to key by. The key is the new API name.
-     *
-     * @return unmodifiable map of componentType to (new API name -> controller-service type)
-     */
-    public Map<String, Map<String, String>> getTypeToControllerServiceRefs() {
-        return Collections.unmodifiableMap(typeToControllerServiceRefs);
-    }
-
-    /**
      * Returns the mapping of component type to subfolder name.
      *
      * @return unmodifiable map of componentType to subfolder
@@ -191,7 +177,6 @@ public class JsonComparator {
         allowedToDelete.clear();
         csvRecords.clear();
         typeToChangedProperties.clear();
-        typeToControllerServiceRefs.clear();
         typeToFolderMap.clear();
     }
 
@@ -414,7 +399,6 @@ public class JsonComparator {
                             new PropertyNames(sourceProp.getDisplayName(), matchingTarget.getDisplayName(),
                                     sourceProp.getApiName(), matchingTarget.getApiName()), csType));
                     recordRename(componentType, sourceProp.getApiName(), matchingTarget.getApiName());
-                    recordControllerServiceRef(componentType, matchingTarget.getApiName(), csType);
                 }
             } else {
                 String csType = sourceProp.getControllerServiceType();
@@ -424,7 +408,6 @@ public class JsonComparator {
                 if (isDeleteAllowed(componentType, sourceProp.getDisplayName())) {
                     recordDeleted(componentType, sourceProp.getApiName());
                 }
-                // Deleted properties are intentionally skipped: they have no new API name to key by.
             }
         }
     }
@@ -445,8 +428,6 @@ public class JsonComparator {
                 csvRecords.add(createCsvRecord(fileName, componentFolder, "added",
                         new PropertyNames("", targetProp.getDisplayName(),
                                 "", targetProp.getApiName()), csType));
-                // Added properties are intentionally skipped in the references map: the JSON
-                // mapping records only renamed and removed properties, not added ones.
             }
         }
     }
@@ -473,14 +454,6 @@ public class JsonComparator {
     private void recordDeleted(String componentType, String apiName) {
         typeToChangedProperties.computeIfAbsent(componentType, k -> new HashMap<>())
                 .put(apiName, null);
-    }
-
-    private void recordControllerServiceRef(String componentType, String displayName, String csType) {
-        if (componentType == null || displayName == null || csType == null) {
-            return;
-        }
-        typeToControllerServiceRefs.computeIfAbsent(componentType, k -> new HashMap<>())
-                .put(displayName, csType);
     }
 
     /**

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonMappingGenerator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonMappingGenerator.java
@@ -20,6 +20,8 @@ public class JsonMappingGenerator {
 
     private static final String JSON_OUTPUT_FILE = "NiFiTypeMapping.json";
 
+    private static final String CONTROLLER_SERVICE_REFERENCES_KEY = "controllerServiceReferences";
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final Set<String> INCLUDED_FOLDERS = Set.of(
@@ -44,12 +46,20 @@ public class JsonMappingGenerator {
      * <p>
      * Renamed properties are written as {@code "oldName": "newName"}.
      * Deleted properties are written as {@code "apiName": null}.
+     * <p>
+     * Renamed properties that reference a controller service are additionally written
+     * under a sibling {@code controllerServiceReferences} object as
+     * {@code "componentType": {"newApiName": "controllerServiceType"}}. The section is
+     * omitted when there are no such references.
      *
-     * @param typeToChangedProperties map of componentType to (name → newName or null) changes
-     * @param typeToFolderMap         map of componentType to subfolder name
+     * @param typeToChangedProperties      map of componentType to (name -> newName or null) changes
+     * @param typeToFolderMap              map of componentType to subfolder name
+     * @param typeToControllerServiceRefs  map of componentType to (new API name ->
+     *                                     controller-service type) for CS-reference properties
      */
     public void generate(Map<String, Map<String, String>> typeToChangedProperties,
-                         Map<String, String> typeToFolderMap) {
+                         Map<String, String> typeToFolderMap,
+                         Map<String, Map<String, String>> typeToControllerServiceRefs) {
         LOGGER.info("Generating type mapping JSON...");
 
         ObjectNode rootNode = OBJECT_MAPPER.createObjectNode();
@@ -70,6 +80,8 @@ public class JsonMappingGenerator {
             rootNode.set(type, typeNode);
         });
 
+        addControllerServiceReferences(rootNode, typeToControllerServiceRefs, typeToFolderMap);
+
         try (FileWriter writer = new FileWriter(getOutputPath())) {
             writer.write(OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
                     .writeValueAsString(rootNode));
@@ -77,6 +89,33 @@ public class JsonMappingGenerator {
             LOGGER.info("Total types with changes: {}", rootNode.size());
         } catch (IOException e) {
             LOGGER.error("Error writing JSON file: {}", e.getMessage(), e);
+        }
+    }
+
+    private void addControllerServiceReferences(ObjectNode rootNode,
+                                                Map<String, Map<String, String>> typeToControllerServiceRefs,
+                                                Map<String, String> typeToFolderMap) {
+        if (typeToControllerServiceRefs == null || typeToControllerServiceRefs.isEmpty()) {
+            return;
+        }
+
+        ObjectNode referencesNode = OBJECT_MAPPER.createObjectNode();
+        typeToControllerServiceRefs.forEach((type, refs) -> {
+            String folder = typeToFolderMap.get(type);
+            if (folder != null && !INCLUDED_FOLDERS.contains(folder)) {
+                return;
+            }
+            if (refs == null || refs.isEmpty()) {
+                return;
+            }
+            ObjectNode typeNode = OBJECT_MAPPER.createObjectNode();
+            refs.forEach(typeNode::put);
+            referencesNode.set(type, typeNode);
+        });
+
+        if (!referencesNode.isEmpty()) {
+            rootNode.set(CONTROLLER_SERVICE_REFERENCES_KEY, referencesNode);
+            LOGGER.info("Controller-service references written for {} types", referencesNode.size());
         }
     }
 

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonMappingGenerator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/JsonMappingGenerator.java
@@ -18,54 +18,64 @@ public class JsonMappingGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonMappingGenerator.class);
 
-    private static final String JSON_OUTPUT_FILE = "NiFiTypeMapping.json";
+    private static final String DEFAULT_OUTPUT_FILE = "NiFiTypeMapping.json";
 
-    private static final String CONTROLLER_SERVICE_REFERENCES_KEY = "controllerServiceReferences";
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    private static final Set<String> INCLUDED_FOLDERS = Set.of(
+    private static final Set<String> DEFAULT_INCLUDED_FOLDERS = Set.of(
             "controllerService", "reportingTask"
     );
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final Path outputDir;
 
+    private final String outputFileName;
+
+    private final Set<String> includedFolders;
+
     /**
-     * Creates a new JSON mapping generator.
+     * Creates a JSON mapping generator for controller-service and reporting-task types.
+     * Writes to {@code NiFiTypeMapping.json}.
      *
      * @param outputDirValue directory where the JSON file will be written
      */
     public JsonMappingGenerator(final Path outputDirValue) {
+        this(outputDirValue, DEFAULT_OUTPUT_FILE, DEFAULT_INCLUDED_FOLDERS);
+    }
+
+    /**
+     * Creates a JSON mapping generator for a specific output file and set of subfolders.
+     *
+     * @param outputDirValue      directory where the JSON file will be written
+     * @param outputFileNameValue name of the JSON file to write
+     * @param includedFoldersValue subfolders whose types are included in the output
+     */
+    public JsonMappingGenerator(final Path outputDirValue,
+                                final String outputFileNameValue,
+                                final Set<String> includedFoldersValue) {
         this.outputDir = outputDirValue;
+        this.outputFileName = outputFileNameValue;
+        this.includedFolders = includedFoldersValue;
     }
 
     /**
      * Generates the type-mapping JSON file.
-     * Components whose subfolder is not in {@link #INCLUDED_FOLDERS}
-     * (e.g. processors) are excluded from the output.
+     * Components whose subfolder is not in the configured included folders are excluded
+     * from the output.
      * <p>
      * Renamed properties are written as {@code "oldName": "newName"}.
      * Deleted properties are written as {@code "apiName": null}.
-     * <p>
-     * Renamed properties that reference a controller service are additionally written
-     * under a sibling {@code controllerServiceReferences} object as
-     * {@code "componentType": {"newApiName": "controllerServiceType"}}. The section is
-     * omitted when there are no such references.
      *
-     * @param typeToChangedProperties      map of componentType to (name -> newName or null) changes
-     * @param typeToFolderMap              map of componentType to subfolder name
-     * @param typeToControllerServiceRefs  map of componentType to (new API name ->
-     *                                     controller-service type) for CS-reference properties
+     * @param typeToChangedProperties map of componentType to (name -> newName or null) changes
+     * @param typeToFolderMap         map of componentType to subfolder name
      */
     public void generate(Map<String, Map<String, String>> typeToChangedProperties,
-                         Map<String, String> typeToFolderMap,
-                         Map<String, Map<String, String>> typeToControllerServiceRefs) {
-        LOGGER.info("Generating type mapping JSON...");
+                         Map<String, String> typeToFolderMap) {
+        LOGGER.info("Generating type mapping JSON for {}...", outputFileName);
 
         ObjectNode rootNode = OBJECT_MAPPER.createObjectNode();
         typeToChangedProperties.forEach((type, changes) -> {
             String folder = typeToFolderMap.get(type);
-            if (folder != null && !INCLUDED_FOLDERS.contains(folder)) {
+            if (folder != null && !includedFolders.contains(folder)) {
                 LOGGER.debug("Skipping type {} from folder '{}' in JSON mapping", type, folder);
                 return;
             }
@@ -80,8 +90,6 @@ public class JsonMappingGenerator {
             rootNode.set(type, typeNode);
         });
 
-        addControllerServiceReferences(rootNode, typeToControllerServiceRefs, typeToFolderMap);
-
         try (FileWriter writer = new FileWriter(getOutputPath())) {
             writer.write(OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
                     .writeValueAsString(rootNode));
@@ -92,39 +100,12 @@ public class JsonMappingGenerator {
         }
     }
 
-    private void addControllerServiceReferences(ObjectNode rootNode,
-                                                Map<String, Map<String, String>> typeToControllerServiceRefs,
-                                                Map<String, String> typeToFolderMap) {
-        if (typeToControllerServiceRefs == null || typeToControllerServiceRefs.isEmpty()) {
-            return;
-        }
-
-        ObjectNode referencesNode = OBJECT_MAPPER.createObjectNode();
-        typeToControllerServiceRefs.forEach((type, refs) -> {
-            String folder = typeToFolderMap.get(type);
-            if (folder != null && !INCLUDED_FOLDERS.contains(folder)) {
-                return;
-            }
-            if (refs == null || refs.isEmpty()) {
-                return;
-            }
-            ObjectNode typeNode = OBJECT_MAPPER.createObjectNode();
-            refs.forEach(typeNode::put);
-            referencesNode.set(type, typeNode);
-        });
-
-        if (!referencesNode.isEmpty()) {
-            rootNode.set(CONTROLLER_SERVICE_REFERENCES_KEY, referencesNode);
-            LOGGER.info("Controller-service references written for {} types", referencesNode.size());
-        }
-    }
-
     /**
      * Returns the absolute path of the JSON output file.
      *
-     * @return absolute path to NiFiTypeMapping.json
+     * @return absolute path to the configured JSON output file
      */
     public String getOutputPath() {
-        return outputDir.resolve(JSON_OUTPUT_FILE).toAbsolutePath().toString();
+        return outputDir.resolve(outputFileName).toAbsolutePath().toString();
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/Main.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/Main.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 
 /**
  * Main entrypoint for component comparator tool.
@@ -70,16 +71,22 @@ public final class Main {
             JsonMappingGenerator jsonGenerator = new JsonMappingGenerator(outputDir);
             jsonGenerator.generate(
                     comparator.getTypeToChangedProperties(),
-                    comparator.getTypeToFolderMap(),
-                    comparator.getTypeToControllerServiceRefs());
+                    comparator.getTypeToFolderMap());
+
+            JsonMappingGenerator processorJsonGenerator = new JsonMappingGenerator(
+                    outputDir, "NiFiProcessorTypeMapping.json", Set.of("processors"));
+            processorJsonGenerator.generate(
+                    comparator.getTypeToChangedProperties(),
+                    comparator.getTypeToFolderMap());
 
             MarkdownReportGenerator mdGenerator = new MarkdownReportGenerator(outputDir);
             mdGenerator.generate(comparator.getCsvRecords());
 
             LOGGER.info("Comparison completed successfully!");
-            LOGGER.info("CSV Report:      {}", csvGenerator.getOutputPath());
-            LOGGER.info("JSON Report:     {}", jsonGenerator.getOutputPath());
-            LOGGER.info("Markdown Report: {}", mdGenerator.getOutputPath());
+            LOGGER.info("CSV Report:           {}", csvGenerator.getOutputPath());
+            LOGGER.info("JSON Report:          {}", jsonGenerator.getOutputPath());
+            LOGGER.info("Processor JSON Report: {}", processorJsonGenerator.getOutputPath());
+            LOGGER.info("Markdown Report:      {}", mdGenerator.getOutputPath());
 
         } catch (IOException e) {
             LOGGER.error("Fatal error during comparison: {}", e.getMessage(), e);

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/Main.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/Main.java
@@ -70,7 +70,8 @@ public final class Main {
             JsonMappingGenerator jsonGenerator = new JsonMappingGenerator(outputDir);
             jsonGenerator.generate(
                     comparator.getTypeToChangedProperties(),
-                    comparator.getTypeToFolderMap());
+                    comparator.getTypeToFolderMap(),
+                    comparator.getTypeToControllerServiceRefs());
 
             MarkdownReportGenerator mdGenerator = new MarkdownReportGenerator(outputDir);
             mdGenerator.generate(comparator.getCsvRecords());

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/MarkdownReportGenerator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/MarkdownReportGenerator.java
@@ -32,9 +32,11 @@ public class MarkdownReportGenerator {
     );
 
     private static final String TABLE_HEADER =
-            "| Change Type | Old Display Name | New Display Name | Old Api Name | New Api Name |";
+            "| Change Type | Old Display Name | New Display Name | Old Api Name | New Api Name "
+                    + "| Controller Service Reference |";
     private static final String TABLE_SEPARATOR =
-            "|-------------|------------------|------------------|--------------|--------------|";
+            "|-------------|------------------|------------------|--------------|--------------"
+                    + "|------------------------------|";
 
     private static final int IDX_COMPONENT_NAME = 0;
     private static final int IDX_COMPONENT_TYPE = 1;
@@ -43,6 +45,7 @@ public class MarkdownReportGenerator {
     private static final int IDX_NEW_DISPLAY_NAME = 4;
     private static final int IDX_OLD_API_NAME = 5;
     private static final int IDX_NEW_API_NAME = 6;
+    private static final int IDX_CS_REF = 7;
 
     private final Path outputDir;
 
@@ -119,6 +122,7 @@ public class MarkdownReportGenerator {
         long renamed = countByChangeType(csvRecords, "rename");
         long deleted = countByChangeType(csvRecords, "deleted");
         long added = countByChangeType(csvRecords, "added");
+        long controllerServiceRefs = countControllerServiceRefs(csvRecords);
         long affectedComponents = csvRecords.stream()
                 .map(r -> r[IDX_COMPONENT_NAME])
                 .distinct()
@@ -131,6 +135,8 @@ public class MarkdownReportGenerator {
         sb.append("| Renamed properties | ").append(renamed).append(" |\n");
         sb.append("| Deleted properties | ").append(deleted).append(" |\n");
         sb.append("| Added properties | ").append(added).append(" |\n");
+        sb.append("| Controller service reference changes | ")
+                .append(controllerServiceRefs).append(" |\n");
         sb.append("| Affected components | ").append(affectedComponents).append(" |\n");
         sb.append("\n");
 
@@ -140,8 +146,8 @@ public class MarkdownReportGenerator {
     private void appendComponentTypeSummary(StringBuilder sb,
                                             Map<String, Map<String, List<String[]>>> grouped) {
         sb.append("### Changes by Component Type\n\n");
-        sb.append("| Component Type | Renamed | Deleted | Added | Total |\n");
-        sb.append("|----------------|--------:|--------:|------:|------:|\n");
+        sb.append("| Component Type | Renamed | Deleted | Added | CS Refs | Total |\n");
+        sb.append("|----------------|--------:|--------:|------:|--------:|------:|\n");
 
         for (String folder : FOLDER_ORDER) {
             Map<String, List<String[]>> components = grouped.get(folder);
@@ -150,6 +156,7 @@ public class MarkdownReportGenerator {
             long renamed = countByChangeType(allRecords, "rename");
             long deletedCount = countByChangeType(allRecords, "deleted");
             long addedCount = countByChangeType(allRecords, "added");
+            long csRefs = countControllerServiceRefs(allRecords);
             long total = allRecords.size();
 
             String displayName = FOLDER_DISPLAY_NAMES.getOrDefault(folder, folder);
@@ -157,6 +164,7 @@ public class MarkdownReportGenerator {
                     .append(" | ").append(renamed)
                     .append(" | ").append(deletedCount)
                     .append(" | ").append(addedCount)
+                    .append(" | ").append(csRefs)
                     .append(" | ").append(total)
                     .append(" |\n");
         }
@@ -186,7 +194,8 @@ public class MarkdownReportGenerator {
                             .append(escapeCell(csvRecord[IDX_OLD_DISPLAY_NAME])).append(" | ")
                             .append(escapeCell(csvRecord[IDX_NEW_DISPLAY_NAME])).append(" | ")
                             .append(escapeCell(csvRecord[IDX_OLD_API_NAME])).append(" | ")
-                            .append(escapeCell(csvRecord[IDX_NEW_API_NAME])).append(" |\n");
+                            .append(escapeCell(csvRecord[IDX_NEW_API_NAME])).append(" | ")
+                            .append(escapeCell(cellAt(csvRecord, IDX_CS_REF))).append(" |\n");
                 }
                 sb.append("\n");
             }
@@ -197,6 +206,19 @@ public class MarkdownReportGenerator {
         return records.stream()
                 .filter(r -> changeType.equals(r[IDX_CHANGE_TYPE]))
                 .count();
+    }
+
+    private long countControllerServiceRefs(List<String[]> records) {
+        return records.stream()
+                .filter(r -> !cellAt(r, IDX_CS_REF).isEmpty())
+                .count();
+    }
+
+    private String cellAt(String[] record, int index) {
+        if (record == null || index >= record.length || record[index] == null) {
+            return "";
+        }
+        return record[index];
     }
 
     private List<String[]> flattenRecords(Map<String, List<String[]>> components) {

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/MarkdownReportGenerator.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/main/java/org/qubership/nifi/tools/compare/MarkdownReportGenerator.java
@@ -119,10 +119,12 @@ public class MarkdownReportGenerator {
     private void appendSummary(StringBuilder sb,
                                List<String[]> csvRecords,
                                Map<String, Map<String, List<String[]>>> grouped) {
-        long renamed = countByChangeType(csvRecords, "rename");
-        long deleted = countByChangeType(csvRecords, "deleted");
-        long added = countByChangeType(csvRecords, "added");
-        long controllerServiceRefs = countControllerServiceRefs(csvRecords);
+        long renamed = countNonCsRefByChangeType(csvRecords, "rename");
+        long deleted = countNonCsRefByChangeType(csvRecords, "deleted");
+        long added = countNonCsRefByChangeType(csvRecords, "added");
+        long csRenamed = countControllerServiceRefsByChangeType(csvRecords, "rename");
+        long csDeleted = countControllerServiceRefsByChangeType(csvRecords, "deleted");
+        long csAdded = countControllerServiceRefsByChangeType(csvRecords, "added");
         long affectedComponents = csvRecords.stream()
                 .map(r -> r[IDX_COMPONENT_NAME])
                 .distinct()
@@ -135,8 +137,9 @@ public class MarkdownReportGenerator {
         sb.append("| Renamed properties | ").append(renamed).append(" |\n");
         sb.append("| Deleted properties | ").append(deleted).append(" |\n");
         sb.append("| Added properties | ").append(added).append(" |\n");
-        sb.append("| Controller service reference changes | ")
-                .append(controllerServiceRefs).append(" |\n");
+        sb.append("| Renamed controller service references | ").append(csRenamed).append(" |\n");
+        sb.append("| Deleted controller service references | ").append(csDeleted).append(" |\n");
+        sb.append("| Added controller service references | ").append(csAdded).append(" |\n");
         sb.append("| Affected components | ").append(affectedComponents).append(" |\n");
         sb.append("\n");
 
@@ -146,17 +149,21 @@ public class MarkdownReportGenerator {
     private void appendComponentTypeSummary(StringBuilder sb,
                                             Map<String, Map<String, List<String[]>>> grouped) {
         sb.append("### Changes by Component Type\n\n");
-        sb.append("| Component Type | Renamed | Deleted | Added | CS Refs | Total |\n");
-        sb.append("|----------------|--------:|--------:|------:|--------:|------:|\n");
+        sb.append("| Component Type | Renamed | Deleted | Added | CS Ref Renamed | CS Ref Deleted "
+                + "| CS Ref Added | Total |\n");
+        sb.append("|----------------|--------:|--------:|------:|---------------:|---------------:"
+                + "|-------------:|------:|\n");
 
         for (String folder : FOLDER_ORDER) {
             Map<String, List<String[]>> components = grouped.get(folder);
             List<String[]> allRecords = flattenRecords(components);
 
-            long renamed = countByChangeType(allRecords, "rename");
-            long deletedCount = countByChangeType(allRecords, "deleted");
-            long addedCount = countByChangeType(allRecords, "added");
-            long csRefs = countControllerServiceRefs(allRecords);
+            long renamed = countNonCsRefByChangeType(allRecords, "rename");
+            long deletedCount = countNonCsRefByChangeType(allRecords, "deleted");
+            long addedCount = countNonCsRefByChangeType(allRecords, "added");
+            long csRenamed = countControllerServiceRefsByChangeType(allRecords, "rename");
+            long csDeleted = countControllerServiceRefsByChangeType(allRecords, "deleted");
+            long csAdded = countControllerServiceRefsByChangeType(allRecords, "added");
             long total = allRecords.size();
 
             String displayName = FOLDER_DISPLAY_NAMES.getOrDefault(folder, folder);
@@ -164,7 +171,9 @@ public class MarkdownReportGenerator {
                     .append(" | ").append(renamed)
                     .append(" | ").append(deletedCount)
                     .append(" | ").append(addedCount)
-                    .append(" | ").append(csRefs)
+                    .append(" | ").append(csRenamed)
+                    .append(" | ").append(csDeleted)
+                    .append(" | ").append(csAdded)
                     .append(" | ").append(total)
                     .append(" |\n");
         }
@@ -202,15 +211,17 @@ public class MarkdownReportGenerator {
         }
     }
 
-    private long countByChangeType(List<String[]> records, String changeType) {
+    private long countNonCsRefByChangeType(List<String[]> records, String changeType) {
         return records.stream()
+                .filter(r -> cellAt(r, IDX_CS_REF).isEmpty())
                 .filter(r -> changeType.equals(r[IDX_CHANGE_TYPE]))
                 .count();
     }
 
-    private long countControllerServiceRefs(List<String[]> records) {
+    private long countControllerServiceRefsByChangeType(List<String[]> records, String changeType) {
         return records.stream()
                 .filter(r -> !cellAt(r, IDX_CS_REF).isEmpty())
+                .filter(r -> changeType.equals(r[IDX_CHANGE_TYPE]))
                 .count();
     }
 

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/CsvReportGeneratorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/CsvReportGeneratorTest.java
@@ -43,6 +43,7 @@ class CsvReportGeneratorTest {
         assertEquals(1, lines.size(), "Only header expected for empty records");
         assertTrue(lines.get(0).contains("Component Name"));
         assertTrue(lines.get(0).contains("Change Type"));
+        assertTrue(lines.get(0).contains("Controller Service Reference"));
     }
 
     @Test

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonComparatorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonComparatorTest.java
@@ -575,7 +575,7 @@ class JsonComparatorTest {
     }
 
     @Test
-    void renamedCsRefByValueSetsCsRefColumnAndRefsMap() throws IOException {
+    void renamedCsRefByValueSetsCsRefColumn() throws IOException {
         String csType = "org.apache.nifi.dbcp.DBCPService";
         writeJson(sourceDir, "processors", "ExecuteSQL.json", "org.example.ExecuteSQL",
                 propWithCsByValue("old-api", "Database Connection Pooling Service", csType));
@@ -588,10 +588,6 @@ class JsonComparatorTest {
         assertEquals(1, records.size());
         assertEquals("rename", records.get(0)[2]);
         assertEquals(csType, records.get(0)[7]);
-
-        Map<String, String> refs = comparator.getTypeToControllerServiceRefs()
-                .get("org.example.ExecuteSQL");
-        assertEquals(csType, refs.get("new-api"));
     }
 
     @Test
@@ -607,12 +603,10 @@ class JsonComparatorTest {
         List<String[]> records = comparator.getCsvRecords();
         assertEquals(1, records.size());
         assertEquals(csType, records.get(0)[7]);
-        assertEquals(csType, comparator.getTypeToControllerServiceRefs()
-                .get("org.example.Svc").get("new-api"));
     }
 
     @Test
-    void deletedCsRefSetsCsRefColumnButIsSkippedInRefsMap() throws IOException {
+    void deletedCsRefSetsCsRefColumn() throws IOException {
         String csType = "org.apache.nifi.dbcp.DBCPService";
         writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
                 prop("keep", "Keep") + ","
@@ -626,12 +620,10 @@ class JsonComparatorTest {
         assertEquals(1, records.size());
         assertEquals("deleted", records.get(0)[2]);
         assertEquals(csType, records.get(0)[7]);
-        // Deleted properties are skipped in the references map (no new API name to key by).
-        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
     }
 
     @Test
-    void addedCsRefSetsCsRefColumnButIsSkippedInRefsMap() throws IOException {
+    void addedCsRefSetsCsRefColumn() throws IOException {
         String csType = "org.apache.nifi.ssl.SSLContextService";
         writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
                 prop("keep", "Keep"));
@@ -645,8 +637,6 @@ class JsonComparatorTest {
         assertEquals(1, records.size());
         assertEquals("added", records.get(0)[2]);
         assertEquals(csType, records.get(0)[7]);
-        // Added properties are skipped in the references map (JSON records only renamed/removed).
-        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
     }
 
     @Test
@@ -661,6 +651,5 @@ class JsonComparatorTest {
         List<String[]> records = comparator.getCsvRecords();
         assertEquals(1, records.size());
         assertEquals("", records.get(0)[7]);
-        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonComparatorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonComparatorTest.java
@@ -54,6 +54,24 @@ class JsonComparatorTest {
                 apiName, apiName, displayName, description);
     }
 
+    // Property descriptor with a typeProvidedByValue controller-service reference (NiFi 2.x).
+    private String propWithCsByValue(String apiName, String displayName, String csType) {
+        return String.format(
+                "\"%s\":{\"name\":\"%s\",\"displayName\":\"%s\",\"description\":\"\","
+                        + "\"typeProvidedByValue\":{\"group\":\"org.apache.nifi\","
+                        + "\"artifact\":\"nifi-standard-services-api-nar\","
+                        + "\"version\":\"2.0.0\",\"type\":\"%s\"}}",
+                apiName, apiName, displayName, csType);
+    }
+
+    // Property descriptor with an identifiesControllerService reference (NiFi 1.x).
+    private String propWithCsIdentifies(String apiName, String displayName, String csType) {
+        return String.format(
+                "\"%s\":{\"name\":\"%s\",\"displayName\":\"%s\",\"description\":\"\","
+                        + "\"identifiesControllerService\":\"%s\"}",
+                apiName, apiName, displayName, csType);
+    }
+
     private void loadAndCompare() throws IOException {
         comparator.load(sourceDir.toString(), targetDir.toString(), null);
         comparator.compare();
@@ -554,5 +572,95 @@ class JsonComparatorTest {
         assertEquals(2, props.size());
         assertEquals("new-api", props.get("old-api"));
         assertNull(props.get("kerb-api"));
+    }
+
+    @Test
+    void renamedCsRefByValueSetsCsRefColumnAndRefsMap() throws IOException {
+        String csType = "org.apache.nifi.dbcp.DBCPService";
+        writeJson(sourceDir, "processors", "ExecuteSQL.json", "org.example.ExecuteSQL",
+                propWithCsByValue("old-api", "Database Connection Pooling Service", csType));
+        writeJson(targetDir, "processors", "ExecuteSQL.json", "org.example.ExecuteSQL",
+                propWithCsByValue("new-api", "Database Connection Pooling Service", csType));
+
+        loadAndCompare();
+
+        List<String[]> records = comparator.getCsvRecords();
+        assertEquals(1, records.size());
+        assertEquals("rename", records.get(0)[2]);
+        assertEquals(csType, records.get(0)[7]);
+
+        Map<String, String> refs = comparator.getTypeToControllerServiceRefs()
+                .get("org.example.ExecuteSQL");
+        assertEquals(csType, refs.get("new-api"));
+    }
+
+    @Test
+    void renamedCsRefIdentifiesSetsCsRefColumn() throws IOException {
+        String csType = "org.apache.nifi.proxy.ProxyConfigurationService";
+        writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
+                propWithCsIdentifies("old-api", "Proxy Configuration Service", csType));
+        writeJson(targetDir, "controllerService", "Svc.json", "org.example.Svc",
+                propWithCsIdentifies("new-api", "Proxy Configuration Service", csType));
+
+        loadAndCompare();
+
+        List<String[]> records = comparator.getCsvRecords();
+        assertEquals(1, records.size());
+        assertEquals(csType, records.get(0)[7]);
+        assertEquals(csType, comparator.getTypeToControllerServiceRefs()
+                .get("org.example.Svc").get("new-api"));
+    }
+
+    @Test
+    void deletedCsRefSetsCsRefColumnButIsSkippedInRefsMap() throws IOException {
+        String csType = "org.apache.nifi.dbcp.DBCPService";
+        writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
+                prop("keep", "Keep") + ","
+                        + propWithCsByValue("gone", "Connection Pool", csType));
+        writeJson(targetDir, "controllerService", "Svc.json", "org.example.Svc",
+                prop("keep", "Keep"));
+
+        loadAndCompare();
+
+        List<String[]> records = comparator.getCsvRecords();
+        assertEquals(1, records.size());
+        assertEquals("deleted", records.get(0)[2]);
+        assertEquals(csType, records.get(0)[7]);
+        // Deleted properties are skipped in the references map (no new API name to key by).
+        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
+    }
+
+    @Test
+    void addedCsRefSetsCsRefColumnButIsSkippedInRefsMap() throws IOException {
+        String csType = "org.apache.nifi.ssl.SSLContextService";
+        writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
+                prop("keep", "Keep"));
+        writeJson(targetDir, "controllerService", "Svc.json", "org.example.Svc",
+                prop("keep", "Keep") + ","
+                        + propWithCsByValue("new-prop", "SSL Context Service", csType));
+
+        loadAndCompare();
+
+        List<String[]> records = comparator.getCsvRecords();
+        assertEquals(1, records.size());
+        assertEquals("added", records.get(0)[2]);
+        assertEquals(csType, records.get(0)[7]);
+        // Added properties are skipped in the references map (JSON records only renamed/removed).
+        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
+    }
+
+    @Test
+    void nonCsRefChangeLeavesCsRefColumnEmpty() throws IOException {
+        writeJson(sourceDir, "processors", "Proc.json", "org.example.Proc",
+                prop("old-api", "Display"));
+        writeJson(targetDir, "processors", "Proc.json", "org.example.Proc",
+                prop("new-api", "Display"));
+
+        loadAndCompare();
+
+        List<String[]> records = comparator.getCsvRecords();
+        assertEquals(1, records.size());
+        assertEquals("", records.get(0)[7]);
+        assertTrue(comparator.getTypeToControllerServiceRefs().isEmpty());
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonMappingGeneratorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonMappingGeneratorTest.java
@@ -31,7 +31,7 @@ class JsonMappingGeneratorTest {
     @Test
     void generateEmptyMapsProducesEmptyJsonObject() throws IOException {
         JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
-        gen.generate(Map.of(), Map.of());
+        gen.generate(Map.of(), Map.of(), Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.isObject());
@@ -47,7 +47,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
 
-        gen.generate(renames, folderMap);
+        gen.generate(renames, folderMap, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.has("org.example.MyService"));
@@ -63,7 +63,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyTask", "reportingTask");
 
-        gen.generate(renames, folderMap);
+        gen.generate(renames, folderMap, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.has("org.example.MyTask"));
@@ -78,7 +78,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyProc", "processors");
 
-        gen.generate(renames, folderMap);
+        gen.generate(renames, folderMap, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertFalse(root.has("org.example.MyProc"),
@@ -100,7 +100,7 @@ class JsonMappingGeneratorTest {
                 "org.example.MyTask", "reportingTask"
         );
 
-        gen.generate(renames, folderMap);
+        gen.generate(renames, folderMap, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertEquals(2, root.size(), "Only controllerService and reportingTask expected");
@@ -123,7 +123,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.Svc", "controllerService");
 
-        gen.generate(renames, folderMap);
+        gen.generate(renames, folderMap, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         JsonNode svcNode = root.get("org.example.Svc");
@@ -140,11 +140,65 @@ class JsonMappingGeneratorTest {
         Map<String, Map<String, String>> renames = new HashMap<>();
         renames.put("org.example.Unknown", Map.of("old", "new"));
 
-        // empty folder map — folder is null
-        gen.generate(renames, Map.of());
+        // empty folder map - folder is null
+        gen.generate(renames, Map.of(), Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
-        // folder == null → condition (folder != null && !INCLUDED) is false → type is included
+        // folder == null -> condition (folder != null && !INCLUDED) is false -> type is included
         assertTrue(root.has("org.example.Unknown"));
+    }
+
+    @Test
+    void generateIncludesControllerServiceReferencesSection() throws IOException {
+        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
+
+        Map<String, Map<String, String>> renames = Map.of(
+                "org.example.MyService", Map.of("old-api", "new-api"));
+        Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
+        Map<String, Map<String, String>> refs = Map.of(
+                "org.example.MyService",
+                Map.of("database-connection-pooling-service", "org.apache.nifi.dbcp.DBCPService"));
+
+        gen.generate(renames, folderMap, refs);
+
+        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
+        assertTrue(root.has("org.example.MyService"));
+        assertEquals("new-api", root.get("org.example.MyService").get("old-api").asText());
+
+        JsonNode references = root.get("controllerServiceReferences");
+        assertTrue(references != null && references.has("org.example.MyService"));
+        assertEquals("org.apache.nifi.dbcp.DBCPService",
+                references.get("org.example.MyService")
+                        .get("database-connection-pooling-service").asText());
+    }
+
+    @Test
+    void generateOmitsReferencesSectionWhenEmpty() throws IOException {
+        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
+
+        Map<String, Map<String, String>> renames = Map.of(
+                "org.example.MyService", Map.of("old-api", "new-api"));
+        Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
+
+        gen.generate(renames, folderMap, Map.of());
+
+        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
+        assertFalse(root.has("controllerServiceReferences"));
+    }
+
+    @Test
+    void generateExcludesProcessorReferences() throws IOException {
+        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
+
+        Map<String, String> folderMap = Map.of("org.example.MyProc", "processors");
+        Map<String, Map<String, String>> refs = Map.of(
+                "org.example.MyProc",
+                Map.of("Database Connection Pooling Service", "org.apache.nifi.dbcp.DBCPService"));
+
+        gen.generate(Map.of(), folderMap, refs);
+
+        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
+        assertFalse(root.has("controllerServiceReferences"),
+                "Processor references should be excluded, leaving the section empty and omitted");
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonMappingGeneratorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/JsonMappingGeneratorTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +32,7 @@ class JsonMappingGeneratorTest {
     @Test
     void generateEmptyMapsProducesEmptyJsonObject() throws IOException {
         JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
-        gen.generate(Map.of(), Map.of(), Map.of());
+        gen.generate(Map.of(), Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.isObject());
@@ -47,7 +48,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
 
-        gen.generate(renames, folderMap, Map.of());
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.has("org.example.MyService"));
@@ -63,7 +64,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyTask", "reportingTask");
 
-        gen.generate(renames, folderMap, Map.of());
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertTrue(root.has("org.example.MyTask"));
@@ -78,7 +79,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.MyProc", "processors");
 
-        gen.generate(renames, folderMap, Map.of());
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertFalse(root.has("org.example.MyProc"),
@@ -100,7 +101,7 @@ class JsonMappingGeneratorTest {
                 "org.example.MyTask", "reportingTask"
         );
 
-        gen.generate(renames, folderMap, Map.of());
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         assertEquals(2, root.size(), "Only controllerService and reportingTask expected");
@@ -123,7 +124,7 @@ class JsonMappingGeneratorTest {
 
         Map<String, String> folderMap = Map.of("org.example.Svc", "controllerService");
 
-        gen.generate(renames, folderMap, Map.of());
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         JsonNode svcNode = root.get("org.example.Svc");
@@ -141,7 +142,7 @@ class JsonMappingGeneratorTest {
         renames.put("org.example.Unknown", Map.of("old", "new"));
 
         // empty folder map - folder is null
-        gen.generate(renames, Map.of(), Map.of());
+        gen.generate(renames, Map.of());
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
         // folder == null -> condition (folder != null && !INCLUDED) is false -> type is included
@@ -149,56 +150,54 @@ class JsonMappingGeneratorTest {
     }
 
     @Test
-    void generateIncludesControllerServiceReferencesSection() throws IOException {
-        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
-
-        Map<String, Map<String, String>> renames = Map.of(
-                "org.example.MyService", Map.of("old-api", "new-api"));
-        Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
-        Map<String, Map<String, String>> refs = Map.of(
-                "org.example.MyService",
-                Map.of("database-connection-pooling-service", "org.apache.nifi.dbcp.DBCPService"));
-
-        gen.generate(renames, folderMap, refs);
-
-        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
-        assertTrue(root.has("org.example.MyService"));
-        assertEquals("new-api", root.get("org.example.MyService").get("old-api").asText());
-
-        JsonNode references = root.get("controllerServiceReferences");
-        assertTrue(references != null && references.has("org.example.MyService"));
-        assertEquals("org.apache.nifi.dbcp.DBCPService",
-                references.get("org.example.MyService")
-                        .get("database-connection-pooling-service").asText());
+    void processorGeneratorOutputPathContainsProcessorFileName() {
+        JsonMappingGenerator gen = new JsonMappingGenerator(
+                tempDir, "NiFiProcessorTypeMapping.json", Set.of("processors"));
+        assertTrue(gen.getOutputPath().endsWith("NiFiProcessorTypeMapping.json"));
     }
 
     @Test
-    void generateOmitsReferencesSectionWhenEmpty() throws IOException {
-        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
+    void processorGeneratorIncludesProcessorRenamesAndDeletions() throws IOException {
+        JsonMappingGenerator gen = new JsonMappingGenerator(
+                tempDir, "NiFiProcessorTypeMapping.json", Set.of("processors"));
 
-        Map<String, Map<String, String>> renames = Map.of(
-                "org.example.MyService", Map.of("old-api", "new-api"));
-        Map<String, String> folderMap = Map.of("org.example.MyService", "controllerService");
-
-        gen.generate(renames, folderMap, Map.of());
-
-        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
-        assertFalse(root.has("controllerServiceReferences"));
-    }
-
-    @Test
-    void generateExcludesProcessorReferences() throws IOException {
-        JsonMappingGenerator gen = new JsonMappingGenerator(tempDir);
-
+        Map<String, String> changes = new HashMap<>();
+        changes.put("old-api", "new-api");
+        changes.put("gone-api", null);
+        Map<String, Map<String, String>> renames = Map.of("org.example.MyProc", changes);
         Map<String, String> folderMap = Map.of("org.example.MyProc", "processors");
-        Map<String, Map<String, String>> refs = Map.of(
-                "org.example.MyProc",
-                Map.of("Database Connection Pooling Service", "org.apache.nifi.dbcp.DBCPService"));
 
-        gen.generate(Map.of(), folderMap, refs);
+        gen.generate(renames, folderMap);
 
         JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
-        assertFalse(root.has("controllerServiceReferences"),
-                "Processor references should be excluded, leaving the section empty and omitted");
+        JsonNode procNode = root.get("org.example.MyProc");
+        assertTrue(procNode != null && procNode.has("old-api"));
+        assertEquals("new-api", procNode.get("old-api").asText());
+        assertTrue(procNode.get("gone-api").isNull());
+    }
+
+    @Test
+    void processorGeneratorExcludesControllerServiceAndReportingTask() throws IOException {
+        JsonMappingGenerator gen = new JsonMappingGenerator(
+                tempDir, "NiFiProcessorTypeMapping.json", Set.of("processors"));
+
+        Map<String, Map<String, String>> renames = new HashMap<>();
+        renames.put("org.example.MyProc", Map.of("p-old", "p-new"));
+        renames.put("org.example.MyService", Map.of("s-old", "s-new"));
+        renames.put("org.example.MyTask", Map.of("t-old", "t-new"));
+
+        Map<String, String> folderMap = Map.of(
+                "org.example.MyProc", "processors",
+                "org.example.MyService", "controllerService",
+                "org.example.MyTask", "reportingTask"
+        );
+
+        gen.generate(renames, folderMap);
+
+        JsonNode root = MAPPER.readTree(Path.of(gen.getOutputPath()).toFile());
+        assertEquals(1, root.size(), "Only processors expected");
+        assertTrue(root.has("org.example.MyProc"));
+        assertFalse(root.has("org.example.MyService"));
+        assertFalse(root.has("org.example.MyTask"));
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
@@ -85,6 +85,10 @@ class MainTest {
         return outputDir.resolve("NiFiTypeMapping.json");
     }
 
+    private Path processorJsonPath() {
+        return outputDir.resolve("NiFiProcessorTypeMapping.json");
+    }
+
     private Path mdPath() {
         return outputDir.resolve("NiFiComponentsDelta.md");
     }
@@ -143,7 +147,7 @@ class MainTest {
     }
 
     @Test
-    void mainProcessorsRenameInCsvButNotInJson() throws IOException {
+    void mainProcessorsRenameInCsvAndProcessorJsonButNotInTypeMapping() throws IOException {
         writeJson(sourceDir, "processors", "Proc.json",
                 "org.example.Proc", prop("old-api", "Display"));
         writeJson(targetDir, "processors", "Proc.json",
@@ -156,10 +160,44 @@ class MainTest {
         assertTrue(csv.contains("rename"));
         assertTrue(csv.contains("processors"));
 
-        // JSON should NOT contain processors
+        // NiFiTypeMapping.json should NOT contain processors
         JsonNode json = MAPPER.readTree(jsonPath().toFile());
         assertFalse(json.has("org.example.Proc"),
                 "Processors must be excluded from NiFiTypeMapping.json");
+
+        // NiFiProcessorTypeMapping.json SHOULD contain the processor rename
+        JsonNode procJson = MAPPER.readTree(processorJsonPath().toFile());
+        assertTrue(procJson.has("org.example.Proc"));
+        assertEquals("new-api", procJson.get("org.example.Proc").get("old-api").asText());
+    }
+
+    @Test
+    void mainProcessorTypeMappingExcludesControllerServiceAndReportingTask() throws IOException {
+        writeJson(sourceDir, "processors", "P.json",
+                "org.example.P", prop("p-old", "PD"));
+        writeJson(targetDir, "processors", "P.json",
+                "org.example.P", prop("p-new", "PD"));
+
+        writeJson(sourceDir, "controllerService", "S.json",
+                "org.example.S", prop("s-old", "SD"));
+        writeJson(targetDir, "controllerService", "S.json",
+                "org.example.S", prop("s-new", "SD"));
+
+        runMain();
+
+        JsonNode procJson = MAPPER.readTree(processorJsonPath().toFile());
+        assertEquals(1, procJson.size(), "Only processor types expected");
+        assertTrue(procJson.has("org.example.P"));
+        assertFalse(procJson.has("org.example.S"));
+    }
+
+    @Test
+    void mainEmptyDirectoriesProducesEmptyProcessorJson() throws IOException {
+        runMain();
+
+        assertTrue(Files.exists(processorJsonPath()));
+        JsonNode procJson = MAPPER.readTree(processorJsonPath().toFile());
+        assertEquals(0, procJson.size());
     }
 
     @Test
@@ -270,7 +308,7 @@ class MainTest {
     }
 
     @Test
-    void mainControllerServiceReferenceAppearsInJsonAndMarkdown() throws IOException {
+    void mainControllerServiceReferenceAppearsInCsvAndMarkdown() throws IOException {
         String csType = "org.apache.nifi.dbcp.DBCPService";
         writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
                 propWithCsByValue("old-api", "Database Connection Pooling Service", csType));
@@ -279,12 +317,10 @@ class MainTest {
 
         runMain();
 
-        // JSON: rename map unchanged, plus a controllerServiceReferences section
+        // JSON: rename map only, no controllerServiceReferences section
         JsonNode json = MAPPER.readTree(jsonPath().toFile());
         assertEquals("new-api", json.get("org.example.Svc").get("old-api").asText());
-        JsonNode refs = json.get("controllerServiceReferences");
-        assertTrue(refs != null && refs.has("org.example.Svc"));
-        assertEquals(csType, refs.get("org.example.Svc").get("new-api").asText());
+        assertFalse(json.has("controllerServiceReferences"));
 
         // Markdown: CS type in the table and the summary metric
         String md = Files.readString(mdPath());

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
@@ -325,7 +325,7 @@ class MainTest {
         // Markdown: CS type in the table and the summary metric
         String md = Files.readString(mdPath());
         assertTrue(md.contains(csType));
-        assertTrue(md.contains("| Controller service reference changes | 1 |"));
+        assertTrue(md.contains("| Renamed controller service references | 1 |"));
 
         // CSV: CS type recorded in the new column
         String csv = Files.readString(csvPath());

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MainTest.java
@@ -55,6 +55,16 @@ class MainTest {
                 apiName, apiName, displayName);
     }
 
+    // Property descriptor with a typeProvidedByValue controller-service reference (NiFi 2.x).
+    private String propWithCsByValue(String apiName, String displayName, String csType) {
+        return String.format(
+                "\"%s\":{\"name\":\"%s\",\"displayName\":\"%s\",\"description\":\"\","
+                        + "\"typeProvidedByValue\":{\"group\":\"org.apache.nifi\","
+                        + "\"artifact\":\"nifi-standard-services-api-nar\","
+                        + "\"version\":\"2.0.0\",\"type\":\"%s\"}}",
+                apiName, apiName, displayName, csType);
+    }
+
     private void runMain(String... extraArgs) {
         String[] baseArgs = {
                 "--sourceDir", sourceDir.toString(),
@@ -257,6 +267,33 @@ class MainTest {
         assertTrue(md.contains("## Processors"));
         assertTrue(md.contains("## Controller Services"));
         assertTrue(md.contains("## Reporting Tasks"));
+    }
+
+    @Test
+    void mainControllerServiceReferenceAppearsInJsonAndMarkdown() throws IOException {
+        String csType = "org.apache.nifi.dbcp.DBCPService";
+        writeJson(sourceDir, "controllerService", "Svc.json", "org.example.Svc",
+                propWithCsByValue("old-api", "Database Connection Pooling Service", csType));
+        writeJson(targetDir, "controllerService", "Svc.json", "org.example.Svc",
+                propWithCsByValue("new-api", "Database Connection Pooling Service", csType));
+
+        runMain();
+
+        // JSON: rename map unchanged, plus a controllerServiceReferences section
+        JsonNode json = MAPPER.readTree(jsonPath().toFile());
+        assertEquals("new-api", json.get("org.example.Svc").get("old-api").asText());
+        JsonNode refs = json.get("controllerServiceReferences");
+        assertTrue(refs != null && refs.has("org.example.Svc"));
+        assertEquals(csType, refs.get("org.example.Svc").get("new-api").asText());
+
+        // Markdown: CS type in the table and the summary metric
+        String md = Files.readString(mdPath());
+        assertTrue(md.contains(csType));
+        assertTrue(md.contains("| Controller service reference changes | 1 |"));
+
+        // CSV: CS type recorded in the new column
+        String csv = Files.readString(csvPath());
+        assertTrue(csv.contains(csType));
     }
 
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MarkdownReportGeneratorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MarkdownReportGeneratorTest.java
@@ -141,9 +141,9 @@ class MarkdownReportGeneratorTest {
         gen.generate(records);
 
         String content = Files.readString(Path.of(gen.getOutputPath()));
-        assertTrue(content.contains("| Processors | 1 | 1 | 0 | 2 |"));
-        assertTrue(content.contains("| Controller Services | 0 | 0 | 1 | 1 |"));
-        assertTrue(content.contains("| Reporting Tasks | 0 | 0 | 0 | 0 |"));
+        assertTrue(content.contains("| Processors | 1 | 1 | 0 | 0 | 2 |"));
+        assertTrue(content.contains("| Controller Services | 0 | 0 | 1 | 0 | 1 |"));
+        assertTrue(content.contains("| Reporting Tasks | 0 | 0 | 0 | 0 | 0 |"));
     }
 
     @Test
@@ -194,5 +194,36 @@ class MarkdownReportGeneratorTest {
         assertTrue(content.contains("| rename"));
         assertTrue(content.contains("| deleted"));
         assertTrue(content.contains("| added"));
+    }
+
+    @Test
+    void generateRendersControllerServiceReferenceColumn() throws IOException {
+        MarkdownReportGenerator gen = new MarkdownReportGenerator(tempDir);
+
+        List<String[]> records = new ArrayList<>();
+        records.add(new String[]{"ExecuteSQL", "processors", "rename",
+                "Database Connection Pooling Service", "Database Connection Pooling Service",
+                "old-api", "new-api", "org.apache.nifi.dbcp.DBCPService"});
+        gen.generate(records);
+
+        String content = Files.readString(Path.of(gen.getOutputPath()));
+        assertTrue(content.contains("Controller Service Reference"));
+        assertTrue(content.contains("org.apache.nifi.dbcp.DBCPService"));
+    }
+
+    @Test
+    void generateSummaryCountsControllerServiceReferences() throws IOException {
+        MarkdownReportGenerator gen = new MarkdownReportGenerator(tempDir);
+
+        List<String[]> records = new ArrayList<>();
+        records.add(new String[]{"C1", "controllerService", "rename",
+                "Pool", "Pool", "old", "new", "org.apache.nifi.dbcp.DBCPService"});
+        records.add(new String[]{"C2", "processors", "rename",
+                "Plain", "Plain", "a", "b", ""});
+        gen.generate(records);
+
+        String content = Files.readString(Path.of(gen.getOutputPath()));
+        assertTrue(content.contains("| Controller service reference changes | 1 |"));
+        assertTrue(content.contains("| Controller Services | 1 | 0 | 0 | 1 | 1 |"));
     }
 }

--- a/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MarkdownReportGeneratorTest.java
+++ b/qubership-nifi-tools/qubership-nifi-component-comparator-tool/src/test/java/org/qubership/nifi/tools/compare/MarkdownReportGeneratorTest.java
@@ -141,9 +141,9 @@ class MarkdownReportGeneratorTest {
         gen.generate(records);
 
         String content = Files.readString(Path.of(gen.getOutputPath()));
-        assertTrue(content.contains("| Processors | 1 | 1 | 0 | 0 | 2 |"));
-        assertTrue(content.contains("| Controller Services | 0 | 0 | 1 | 0 | 1 |"));
-        assertTrue(content.contains("| Reporting Tasks | 0 | 0 | 0 | 0 | 0 |"));
+        assertTrue(content.contains("| Processors | 1 | 1 | 0 | 0 | 0 | 0 | 2 |"));
+        assertTrue(content.contains("| Controller Services | 0 | 0 | 1 | 0 | 0 | 0 | 1 |"));
+        assertTrue(content.contains("| Reporting Tasks | 0 | 0 | 0 | 0 | 0 | 0 | 0 |"));
     }
 
     @Test
@@ -223,7 +223,32 @@ class MarkdownReportGeneratorTest {
         gen.generate(records);
 
         String content = Files.readString(Path.of(gen.getOutputPath()));
-        assertTrue(content.contains("| Controller service reference changes | 1 |"));
-        assertTrue(content.contains("| Controller Services | 1 | 0 | 0 | 1 | 1 |"));
+        assertTrue(content.contains("| Renamed controller service references | 1 |"));
+        assertTrue(content.contains("| Deleted controller service references | 0 |"));
+        assertTrue(content.contains("| Added controller service references | 0 |"));
+        // The CS ref rename is excluded from the regular renamed count; only the plain rename remains.
+        assertTrue(content.contains("| Renamed properties | 1 |"));
+        assertTrue(content.contains("| Controller Services | 0 | 0 | 0 | 1 | 0 | 0 | 1 |"));
+    }
+
+    @Test
+    void generateSummarySplitsControllerServiceReferencesByChangeType() throws IOException {
+        MarkdownReportGenerator gen = new MarkdownReportGenerator(tempDir);
+
+        List<String[]> records = new ArrayList<>();
+        records.add(new String[]{"C1", "controllerService", "deleted",
+                "Pool", "", "old", "", "org.apache.nifi.dbcp.DBCPService"});
+        records.add(new String[]{"C2", "controllerService", "added",
+                "", "Pool", "", "new", "org.apache.nifi.dbcp.DBCPService"});
+        gen.generate(records);
+
+        String content = Files.readString(Path.of(gen.getOutputPath()));
+        assertTrue(content.contains("| Renamed controller service references | 0 |"));
+        assertTrue(content.contains("| Deleted controller service references | 1 |"));
+        assertTrue(content.contains("| Added controller service references | 1 |"));
+        // Both changes are CS refs, so the regular deleted/added counts stay at zero.
+        assertTrue(content.contains("| Deleted properties | 0 |"));
+        assertTrue(content.contains("| Added properties | 0 |"));
+        assertTrue(content.contains("| Controller Services | 0 | 0 | 0 | 0 | 1 | 1 | 2 |"));
     }
 }


### PR DESCRIPTION
This PR adds the following changes to property comparison tool:
1. marks properties referencing CS by special marker in CSV and markdown output
2. adds JSON mapping file for processors.