### PR TITLE
feat: BREAKING CHANGE: change groupId for qubership-nifi-export-transform-tool to org.qubership.nifi.plugins

### DIFF
--- a/qubership-nifi-tools/qubership-nifi-export-transform-tool/README.md
+++ b/qubership-nifi-tools/qubership-nifi-export-transform-tool/README.md
@@ -18,12 +18,35 @@ as separate files in version control instead of embedding them inside the flow J
 
 ## Usage
 
+To use plugin prefix instead of full name, add pluginGroup `org.qubership.nifi.plugins` in `settings.xml`:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!--...-->
+    <pluginGroups>
+        <pluginGroup>org.qubership.nifi.plugins</pluginGroup>
+    </pluginGroups>
+    <!--...-->
+</settings>
+```
+
+See Maven
+[documentation](https://maven.apache.org/guides/introduction/introduction-to-plugin-prefix-mapping.html#configuring-maven-to-search-for-plugins)
+for more details.
+
 ### Extract
 
 Extracts processor property values from flow JSON files into separate files:
 
 ```shell
-mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:extract \
+mvn org.qubership.nifi.plugins:qubership-nifi-export-transform-tool:<version>:extract \
+  -Dconfig=<configFile> \
+  -Dexport-dir=<exportDir>
+```
+
+```shell
+mvn nifi-transform:<version>:extract \
   -Dconfig=<configFile> \
   -Dexport-dir=<exportDir>
 ```
@@ -33,7 +56,13 @@ mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:extract \
 Restores processor property values from separate files back into the flow JSON:
 
 ```shell
-mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:build \
+mvn org.qubership.nifi.plugins:qubership-nifi-export-transform-tool:<version>:build \
+  -Dconfig=<configFile> \
+  -Dexport-dir=<exportDir>
+```
+
+```shell
+mvn nifi-transform:<version>:build \
   -Dconfig=<configFile> \
   -Dexport-dir=<exportDir>
 ```
@@ -41,7 +70,14 @@ mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:build \
 To additionally delete the extracted files after a successful Build:
 
 ```shell
-mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:build \
+mvn org.qubership.nifi.plugins:qubership-nifi-export-transform-tool:<version>:build \
+  -Dconfig=<configFile> \
+  -Dexport-dir=<exportDir> \
+  -Ddelete=true
+```
+
+```shell
+mvn nifi-transform:<version>:build \
   -Dconfig=<configFile> \
   -Dexport-dir=<exportDir> \
   -Ddelete=true
@@ -49,11 +85,11 @@ mvn org.qubership.nifi:qubership-nifi-export-transform-tool:<version>:build \
 
 The table below describes the plugin parameters:
 
-| Parameter    | Goal             | Default | Description                                                                                     |
-|--------------|------------------|---------|-------------------------------------------------------------------------------------------------|
-| `config`     | extract, build   | -       | Required. Path to the YAML configuration file specifying which processor types to process.      |
-| `export-dir` | extract, build   | `nifi`  | Path to the directory containing exported NiFi flow JSON files.                                 |
-| `delete`     | build            | `false` | When `true`, deletes extracted files and their directories after a successful Build.            |
+| Parameter    | CLI property | Goal             | Default | Description                                                                                     |
+|--------------|--------------|------------------|---------|-------------------------------------------------------------------------------------------------|
+| `configFile` | `config`     | extract, build   | -       | Required. Path to the YAML configuration file specifying which processor types to process.      |
+| `exportDir`  | `export-dir` | extract, build   | `nifi`  | Path to the directory containing exported NiFi flow JSON files.                                 |
+| `delete`     | `delete`     | build            | `false` | When `true`, deletes extracted files and their directories after a successful Build.            |
 
 ### pom.xml configuration
 

--- a/qubership-nifi-tools/qubership-nifi-export-transform-tool/pom.xml
+++ b/qubership-nifi-tools/qubership-nifi-export-transform-tool/pom.xml
@@ -8,6 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.qubership.nifi.plugins</groupId>
     <artifactId>qubership-nifi-export-transform-tool</artifactId>
     <packaging>maven-plugin</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -41,6 +42,12 @@
             <artifactId>qubership-nifi-tools-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- test -->
         <dependency>
@@ -55,21 +62,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-            <version>${jgit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/qubership-nifi-tools/qubership-nifi-export-transform-tool/src/test/java/org/qubership/nifi/maven/transform/it/ExportTransformIT.java
+++ b/qubership-nifi-tools/qubership-nifi-export-transform-tool/src/test/java/org/qubership/nifi/maven/transform/it/ExportTransformIT.java
@@ -53,7 +53,7 @@ class ExportTransformIT {
         // --- Step 1: Extract ---
         List<String> extractCommand = List.of(
                 mvn,
-                "org.qubership.nifi:qubership-nifi-export-transform-tool:" + pluginVersion + ":extract",
+                "org.qubership.nifi.plugins:qubership-nifi-export-transform-tool:" + pluginVersion + ":extract",
                 "-Dconfig=" + configTarget.toAbsolutePath(),
                 "-Dexport-dir=" + flowDirTarget.toAbsolutePath()
         );
@@ -94,7 +94,7 @@ class ExportTransformIT {
         // --- Step 2: Build ---
         List<String> buildCommand = List.of(
                 mvn,
-                "org.qubership.nifi:qubership-nifi-export-transform-tool:" + pluginVersion + ":build",
+                "org.qubership.nifi.plugins:qubership-nifi-export-transform-tool:" + pluginVersion + ":build",
                 "-Dconfig=" + configTarget.toAbsolutePath(),
                 "-Dexport-dir=" + flowDirTarget.toAbsolutePath()
         );


### PR DESCRIPTION
Change groupId for qubership-nifi-export-transform-tool plugin from org.qubership.nifi to org.qubership.nifi.plugins.
This change moves qubership-nifi-export-transform-tool maven plugin to org.qubership.nifi.plugins group.
Previously it was released under generic group org.qubership.nifi.