### PR TITLE
feat: add workflow for nifi flow diffs in PRs

### DIFF
--- a/.github/maven/flow-diff-maven-settings.xml
+++ b/.github/maven/flow-diff-maven-settings.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for resolving the qubership-nifi-flow-diff-tool plugin from GitHub Packages.
+
+  The root pom declares GitHub Packages only under <repositories> (dependency resolution). A plugin
+  invoked by coordinates resolves from <pluginRepositories>, which the root pom does not declare, so
+  this file adds GitHub Packages as both a <repository> (for the plugin's parent POM chain
+  qubership-nifi-tools -> qubership-nifi) and a <pluginRepository> (for the plugin artifact itself),
+  authenticated with the "github" server. Transitive runtime dependencies (JGit, Jackson) come from
+  Maven Central. Passed to Maven with the settings flag in the nifi-flow-diff workflow.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>flow-diff</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/Netcracker/qubership-nifi</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/Netcracker/qubership-nifi</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>flow-diff</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.github/maven/flow-diff-maven-settings.xml
+++ b/.github/maven/flow-diff-maven-settings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Maven settings for resolving the qubership-nifi-flow-diff-tool plugin from GitHub Packages.
+  Maven settings for resolving the qubership-nifi-flow-diff-tool plugin from GitHub Packages in nifi-flow-diff workflow.
 
-  The root pom declares GitHub Packages only under <repositories> (dependency resolution). A plugin
-  invoked by coordinates resolves from <pluginRepositories>, which the root pom does not declare, so
-  this file adds GitHub Packages as both a <repository> (for the plugin's parent POM chain
-  qubership-nifi-tools -> qubership-nifi) and a <pluginRepository> (for the plugin artifact itself),
-  authenticated with the "github" server. Transitive runtime dependencies (JGit, Jackson) come from
-  Maven Central. Passed to Maven with the settings flag in the nifi-flow-diff workflow.
+  The root pom declares GitHub only under <repositories>, but not under <pluginRepositories>.
+  This file adds GitHub as both a <repository> and a <pluginRepository>, authenticated with workflow's actor/token.
+  Transitive runtime dependencies (JGit, Jackson) come from Maven Central.
 -->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/.github/workflows/nifi-flow-diff-publish.yml
+++ b/.github/workflows/nifi-flow-diff-publish.yml
@@ -13,6 +13,9 @@ on:  # zizmor: ignore[dangerous-triggers] safe: no PR-head checkout, artifact tr
     types: [completed]
 
 permissions: {}
+concurrency:
+  group: nifi-flow-diff-publish-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/.github/workflows/nifi-flow-diff-publish.yml
+++ b/.github/workflows/nifi-flow-diff-publish.yml
@@ -1,0 +1,102 @@
+---
+name: nifi-flow-diff-publish
+
+run-name: nifi-flow-diff-publish
+
+# Publishes the flow diff computed by the nifi-flow-diff workflow as a single sticky PR comment.
+# Triggered by workflow_run, so it always runs from the default branch's copy of this file and never
+# executes PR-head code. It is the only holder of the pull-requests write token. The compute run's
+# artifact is treated strictly as data: downloaded, validated, and posted, never executed.
+on:  # zizmor: ignore[dangerous-triggers] safe: no PR-head checkout, artifact treated as data
+  workflow_run:
+    workflows: [nifi-flow-diff]  # must match the name of the compute workflow
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish sticky comment
+    # Only same-repository (non-fork), non-Dependabot pull_request runs that succeeded. Mirrors the
+    # compute guards so a skipped, fork, or Dependabot run never reaches the write token.
+    # 49699333 is Dependabot's stable id.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.actor.id != 49699333
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # No contents: read - this job never checks out the repo. Posting a PR comment needs
+      # pull-requests: write (PR conversation comments use the issues-comment endpoints, gated by
+      # the pull-requests scope); downloading an artifact from another run needs actions: read.
+      pull-requests: write
+      actions: read
+    steps:
+      # No checkout. The only inputs are the artifact (data) and the workflow_run payload.
+      - name: Download flow diff report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: flow-diff-report
+          path: flow-diff-out
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate artifact
+        run: |
+          set -euo pipefail
+          # Treat every file as untrusted data. Fail closed on anything unexpected.
+          test -f flow-diff-out/comment.md
+          test -f flow-diff-out/reportable
+          grep -Eqx 'true|false' flow-diff-out/reportable
+          test "$(wc -c < flow-diff-out/comment.md)" -le 65536
+          iconv -f UTF-8 -t UTF-8 flow-diff-out/comment.md > /dev/null
+
+      - name: Upsert sticky comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- nifi-flow-diff -->';
+            // github-actions[bot] stable numeric user id; identity is checked by id, not login.
+            const BOT_ID = 41898282;
+
+            // Same-repository PRs populate workflow_run.pull_requests; fork runs are already
+            // excluded by the job condition, so an empty array here is unexpected. Fail safe.
+            const run = context.payload.workflow_run;
+            const pr = run.pull_requests && run.pull_requests[0];
+            if (!pr) {
+              core.info('No pull request associated with the compute run; nothing to post.');
+              return;
+            }
+            const issue_number = pr.number;
+
+            const body = fs.readFileSync('flow-diff-out/comment.md', 'utf8');
+            const reportable = fs.readFileSync('flow-diff-out/reportable', 'utf8').trim() === 'true';
+
+            const { owner, repo } = context.repo;
+
+            // Paginate: a single default page (30) can miss an older marker and cause a duplicate.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const mine = comments.filter(
+              (c) => c.user && c.user.id === BOT_ID && c.body && c.body.includes(marker)
+            );
+
+            if (mine.length > 0) {
+              // Update the canonical (oldest) comment; retire any duplicate markers.
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine[0].id, body });
+              for (const dup of mine.slice(1)) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: dup.id });
+              }
+              core.info(`Updated sticky comment ${mine[0].id}; retired ${mine.length - 1} duplicate(s).`);
+            } else if (reportable) {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Created sticky comment.');
+            } else {
+              // Nothing significant and no prior comment: post the no-change note only as a
+              // replacement, so a workflow-only or first-push technical-only PR stays silent.
+              core.info('No reportable changes and no existing comment; nothing to post.');
+            }

--- a/.github/workflows/nifi-flow-diff-publish.yml
+++ b/.github/workflows/nifi-flow-diff-publish.yml
@@ -1,21 +1,19 @@
 ---
 name: nifi-flow-diff-publish
 
-run-name: nifi-flow-diff-publish
+run-name: 'nifi-flow-diff-publish PR #${{ github.event.workflow_run.pull_requests[0].number }}'
 
 # Publishes the flow diff computed by the nifi-flow-diff workflow as a single sticky PR comment.
 # Triggered by workflow_run, so it always runs from the default branch's copy of this file and never
 # executes PR-head code. It is the only holder of the pull-requests write token. The compute run's
 # artifact is treated strictly as data: downloaded, validated, and posted, never executed.
+# Fork PRs and dependabot PRs are excluded from scope of this workflow.
 on:  # zizmor: ignore[dangerous-triggers] safe: no PR-head checkout, artifact treated as data
   workflow_run:
     workflows: [nifi-flow-diff]  # must match the name of the compute workflow
     types: [completed]
 
 permissions: {}
-concurrency:
-  group: nifi-flow-diff-publish-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: false
 
 jobs:
   publish:
@@ -28,6 +26,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.actor.id != 49699333
+    concurrency:
+      # Use either workflow_run.pull_requests[0].number, if available, or workflow_run.id to group runs:
+      group: nifi-flow-diff-publish-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -74,11 +76,15 @@ jobs:
               return;
             }
             const issue_number = pr.number;
+            const { owner, repo } = context.repo;
+            const { data: livePr } = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
+              if (livePr.head.sha !== run.head_sha) {
+              core.info(`Compute run head ${run.head_sha} is stale; live head is ${livePr.head.sha}. Skipping.`);
+              return;
+            }
 
             const body = fs.readFileSync('flow-diff-out/comment.md', 'utf8');
             const reportable = fs.readFileSync('flow-diff-out/reportable', 'utf8').trim() === 'true';
-
-            const { owner, repo } = context.repo;
 
             // Paginate: a single default page (30) can miss an older marker and cause a duplicate.
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/nifi-flow-diff-publish.yml
+++ b/.github/workflows/nifi-flow-diff-publish.yml
@@ -8,6 +8,9 @@ run-name: 'nifi-flow-diff-publish PR #${{ github.event.workflow_run.pull_request
 # executes PR-head code. It is the only holder of the pull-requests write token. The compute run's
 # artifact is treated strictly as data: downloaded, validated, and posted, never executed.
 # Fork PRs and dependabot PRs are excluded from scope of this workflow.
+# Concurrency serializes publisher runs per PR, but GitHub does not guarantee their ordering. Two
+# pushes in quick succession can therefore leave the comment describing the older of the two. The
+# next push to a watched path corrects it.
 on:  # zizmor: ignore[dangerous-triggers] safe: no PR-head checkout, artifact treated as data
   workflow_run:
     workflows: [nifi-flow-diff]  # must match the name of the compute workflow
@@ -57,6 +60,12 @@ jobs:
           grep -Eqx 'true|false' flow-diff-out/reportable
           test "$(wc -c < flow-diff-out/comment.md)" -le 65536
           iconv -f UTF-8 -t UTF-8 flow-diff-out/comment.md > /dev/null
+          # Enforce the sticky envelope the upsert step relies on: the marker must be the first line
+          # and must occur exactly once, followed by the fixed heading. A body that lost its marker
+          # would break comment deduplication and let every later run append a new bot comment.
+          head -n 1 flow-diff-out/comment.md | grep -Fqx '<!-- nifi-flow-diff -->'
+          test "$(grep -Fc '<!-- nifi-flow-diff -->' flow-diff-out/comment.md)" -eq 1
+          head -n 2 flow-diff-out/comment.md | tail -n 1 | grep -Fqx '## NiFi flow diff'
 
       - name: Upsert sticky comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
@@ -77,11 +86,6 @@ jobs:
             }
             const issue_number = pr.number;
             const { owner, repo } = context.repo;
-            const { data: livePr } = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
-              if (livePr.head.sha !== run.head_sha) {
-              core.info(`Compute run head ${run.head_sha} is stale; live head is ${livePr.head.sha}. Skipping.`);
-              return;
-            }
 
             const body = fs.readFileSync('flow-diff-out/comment.md', 'utf8');
             const reportable = fs.readFileSync('flow-diff-out/reportable', 'utf8').trim() === 'true';

--- a/.github/workflows/nifi-flow-diff.yml
+++ b/.github/workflows/nifi-flow-diff.yml
@@ -4,8 +4,10 @@ name: nifi-flow-diff
 run-name: NiFi flow diff for PR #${{ github.event.pull_request.number }}
 
 # Runs the published qubership-nifi-flow-diff-tool against the NiFi flow fixtures a PR touches and
-# posts a human-readable, significant-changes-only diff as a single sticky PR comment (replaced on
-# each push). Workflow uses the tool's JSON output to decide, if comment is needed.
+# uploads a human-readable, significant-changes-only diff as an artifact. The sibling
+# nifi-flow-diff-publish workflow (workflow_run) posts it as a single sticky PR comment, replaced on
+# each push. This workflow is read-only and holds no write token. It uses the tool's JSON output to
+# decide whether a comment is needed.
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -31,11 +33,10 @@ env:
 jobs:
   compute:
     name: Compute flow diff
-    # Only same-repository, non-Dependabot PRs, non-fork PRs. Fork PRs have a read-only token (cannot comment) and
-    # Dependabot runs get a restricted token. 49699333 is Dependabot's stable id.
+    # Only same-repository (non-fork), non-Dependabot PRs. Fork and Dependabot runs get a restricted
+    # token and are skipped. 49699333 is Dependabot's stable id.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor != 'dependabot[bot]' &&
       github.actor_id != '49699333'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -148,62 +149,3 @@ jobs:
           name: flow-diff-report
           path: flow-diff-out
           retention-days: 5
-
-  publish:
-    name: Publish sticky comment
-    needs: [compute]
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor_id != '49699333'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      # No checkout: this job holds a write token and must never execute PR-head code.
-      - name: Download flow diff report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: flow-diff-report
-          path: flow-diff-out
-
-      - name: Upsert sticky comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- nifi-flow-diff -->';
-            // github-actions[bot] stable numeric user id; identity is checked by id, not login.
-            const BOT_ID = 41898282;
-
-            const body = fs.readFileSync('flow-diff-out/comment.md', 'utf8');
-            const reportable = fs.readFileSync('flow-diff-out/reportable', 'utf8').trim() === 'true';
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-
-            // Paginate: a single default page (30) can miss an older marker and cause a duplicate.
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const mine = comments.filter(
-              (c) => c.user && c.user.id === BOT_ID && c.body && c.body.includes(marker)
-            );
-
-            if (mine.length > 0) {
-              // Update the canonical (oldest) comment; retire any duplicate markers.
-              await github.rest.issues.updateComment({ owner, repo, comment_id: mine[0].id, body });
-              for (const dup of mine.slice(1)) {
-                await github.rest.issues.deleteComment({ owner, repo, comment_id: dup.id });
-              }
-              core.info(`Updated sticky comment ${mine[0].id}; retired ${mine.length - 1} duplicate(s).`);
-            } else if (reportable) {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-              core.info('Created sticky comment.');
-            } else {
-              // Nothing significant and no prior comment: post the no-change note only as a
-              // replacement, so a workflow-only or first-push technical-only PR stays silent.
-              core.info('No reportable changes and no existing comment; nothing to post.');
-            }

--- a/.github/workflows/nifi-flow-diff.yml
+++ b/.github/workflows/nifi-flow-diff.yml
@@ -75,6 +75,8 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This run owns the artifact; the sticky comment is posted by the sibling publisher run.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -107,8 +109,17 @@ jobs:
               -Dpath="${dir}" -Dbranch="${BASE_SHA}" -Dformat=json -Doutput="${out}/${label}.json"
 
             # Reportable = significant + environmental + whole added/removed flows. Technical excluded.
-            sum="$(jq '.totals | (.significant + .environmental + .addedFlows + .removedFlows)' "${out}/${label}.json")"
-            if [ "${sum:-0}" -gt 0 ]; then
+            # jq -e fails when any total is missing or non-numeric, so a tool schema change reports
+            # itself here rather than surfacing as an obscure shell error on the comparison below.
+            if ! sum="$(jq -e '
+                  [.totals.significant, .totals.environmental, .totals.addedFlows, .totals.removedFlows]
+                  | if any(type != "number") then null else add end
+                ' "${out}/${label}.json")"; then
+              echo "Unexpected flow-diff JSON for '${label}': .totals must hold numeric significant," \
+                   "environmental, addedFlows and removedFlows." >&2
+              exit 1
+            fi
+            if [ "${sum}" -gt 0 ]; then
               reportable=true
               printf '\n' >> "${out}/body.md"
               cat "${out}/${label}.md" >> "${out}/body.md"
@@ -133,10 +144,15 @@ jobs:
           limit=60000
           if [ "$(wc -c < "${out}/comment.full.md")" -gt "${limit}" ]; then
             head -c "${limit}" "${out}/comment.full.md" | sed '$ d' > "${out}/comment.md"
+            # Cutting inside a fenced block would render the note below as code: close an odd fence.
+            fences="$(grep -c '^```' "${out}/comment.md" || true)"
+            if [ $((fences % 2)) -ne 0 ]; then
+              printf '```\n' >> "${out}/comment.md"
+            fi
             {
               echo
               echo '---'
-              echo "_Report truncated to fit GitHub's comment size limit. See the full \`flow-diff-report\` artifact on this workflow run._"
+              echo "_Report truncated to fit GitHub's comment size limit. See the full \`flow-diff-report\` artifact on [the compute run](${RUN_URL})._"
             } >> "${out}/comment.md"
           else
             cp "${out}/comment.full.md" "${out}/comment.md"

--- a/.github/workflows/nifi-flow-diff.yml
+++ b/.github/workflows/nifi-flow-diff.yml
@@ -1,13 +1,14 @@
 ---
 name: nifi-flow-diff
 
-run-name: NiFi flow diff for PR #${{ github.event.pull_request.number }}
+run-name: 'NiFi flow diff for PR #${{ github.event.pull_request.number }}'
 
-# Runs the published qubership-nifi-flow-diff-tool against the NiFi flow fixtures a PR touches and
-# uploads a human-readable, significant-changes-only diff as an artifact. The sibling
-# nifi-flow-diff-publish workflow (workflow_run) posts it as a single sticky PR comment, replaced on
-# each push. This workflow is read-only and holds no write token. It uses the tool's JSON output to
-# decide whether a comment is needed.
+# Runs qubership-nifi-flow-diff-tool against the NiFi flow exports modified in the PR and
+# uploads a human-readable, significant-changes-only diff as an artifact.
+# Fork PRs and dependabot PRs are excluded from scope of this workflow.
+# The sibling nifi-flow-diff-publish workflow (workflow_run) posts it as a single sticky PR comment,
+# replaced on each push. If all flow export changes are reverted, the comment on the PR will remain.
+# This workflow is read-only and holds no write token.
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/nifi-flow-diff.yml
+++ b/.github/workflows/nifi-flow-diff.yml
@@ -5,7 +5,7 @@ run-name: NiFi flow diff for PR #${{ github.event.pull_request.number }}
 
 # Runs the published qubership-nifi-flow-diff-tool against the NiFi flow fixtures a PR touches and
 # posts a human-readable, significant-changes-only diff as a single sticky PR comment (replaced on
-# each push, never appended). Workflow uses the tool's JSON output to decide, if comment is needed, not the Markdown.
+# each push). Workflow uses the tool's JSON output to decide, if comment is needed.
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -14,8 +14,8 @@ on:
       - 'dev-tools-integration-tests/src/test/resources/test-flows/flows/**'
       - 'qubership-nifi-tools/qubership-nifi-export-transform-tool/src/test/resources/nifi/**'
       - '.github/workflows/nifi-flow-diff.yml'
+      - '.github/maven/flow-diff-maven-settings.xml'
 
-# Deny by default; each job grants its own minimal set.
 permissions: {}
 
 # Latest push wins: cancel any in-flight run for the same PR so a slower older run cannot overwrite
@@ -31,10 +31,11 @@ env:
 jobs:
   compute:
     name: Compute flow diff
-    # Only same-repository, non-Dependabot PRs. Fork PRs have a read-only token (cannot comment) and
-    # Dependabot runs get a restricted token; both are skipped. 49699333 is Dependabot's stable id.
+    # Only same-repository, non-Dependabot PRs, non-fork PRs. Fork PRs have a read-only token (cannot comment) and
+    # Dependabot runs get a restricted token. 49699333 is Dependabot's stable id.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
       github.actor_id != '49699333'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -153,6 +154,7 @@ jobs:
     needs: [compute]
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
       github.actor_id != '49699333'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/nifi-flow-diff.yml
+++ b/.github/workflows/nifi-flow-diff.yml
@@ -1,0 +1,207 @@
+---
+name: nifi-flow-diff
+
+run-name: NiFi flow diff for PR #${{ github.event.pull_request.number }}
+
+# Runs the published qubership-nifi-flow-diff-tool against the NiFi flow fixtures a PR touches and
+# posts a human-readable, significant-changes-only diff as a single sticky PR comment (replaced on
+# each push, never appended). Workflow uses the tool's JSON output to decide, if comment is needed, not the Markdown.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '.github/collections/nifi-resources/pg/**'
+      - 'dev-tools-integration-tests/src/test/resources/test-flows/flows/**'
+      - 'qubership-nifi-tools/qubership-nifi-export-transform-tool/src/test/resources/nifi/**'
+      - '.github/workflows/nifi-flow-diff.yml'
+
+# Deny by default; each job grants its own minimal set.
+permissions: {}
+
+# Latest push wins: cancel any in-flight run for the same PR so a slower older run cannot overwrite
+# the sticky comment with stale output.
+concurrency:
+  group: nifi-flow-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  # Single place to bump once a newer flow-diff-tool release is published.
+  FLOW_DIFF_TOOL_VERSION: '2.6.3'
+
+jobs:
+  compute:
+    name: Compute flow diff
+    # Only same-repository, non-Dependabot PRs. Fork PRs have a read-only token (cannot comment) and
+    # Dependabot runs get a restricted token; both are skipped. 49699333 is Dependabot's stable id.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor_id != '49699333'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history so the immutable base commit is available to JGit; no persisted credentials
+          # so they cannot leak into the uploaded artifact.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Ensure base commit is present
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "${BASE_SHA}"
+          fi
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run flow-diff tool and assemble comment
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          marker='<!-- nifi-flow-diff -->'
+          out='flow-diff-out'
+          mkdir -p "${out}"
+
+          # label|directory pairs. The label names the per-directory report files.
+          entries=(
+            "pg|.github/collections/nifi-resources/pg"
+            "test-flows|dev-tools-integration-tests/src/test/resources/test-flows/flows"
+            "export-transform|qubership-nifi-tools/qubership-nifi-export-transform-tool/src/test/resources/nifi"
+          )
+
+          plugin="org.qubership.nifi.plugins:qubership-nifi-flow-diff-tool:${FLOW_DIFF_TOOL_VERSION}:git-diff"
+          settings='.github/maven/flow-diff-maven-settings.xml'
+
+          reportable=false
+          : > "${out}/body.md"
+
+          for entry in "${entries[@]}"; do
+            label="${entry%%|*}"
+            dir="${entry#*|}"
+
+            # Markdown for display, JSON to decide, if this should be reported. No -Dskip-malformed: a
+            # malformed flow must fail the job rather than be silently downgraded.
+            mvn -B -q -N --no-transfer-progress --settings "${settings}" "${plugin}" \
+              -Dpath="${dir}" -Dbranch="${BASE_SHA}" -Dformat=md -Doutput="${out}/${label}.md"
+            mvn -B -q -N --no-transfer-progress --settings "${settings}" "${plugin}" \
+              -Dpath="${dir}" -Dbranch="${BASE_SHA}" -Dformat=json -Doutput="${out}/${label}.json"
+
+            # Reportable = significant + environmental + whole added/removed flows. Technical excluded.
+            sum="$(jq '.totals | (.significant + .environmental + .addedFlows + .removedFlows)' "${out}/${label}.json")"
+            if [ "${sum:-0}" -gt 0 ]; then
+              reportable=true
+              printf '\n' >> "${out}/body.md"
+              cat "${out}/${label}.md" >> "${out}/body.md"
+            fi
+          done
+
+          # Build the full comment body: marker, heading, then either the diff or the no-change note.
+          {
+            echo "${marker}"
+            echo '## NiFi flow diff'
+            echo
+            if [ "${reportable}" = true ]; then
+              echo 'Significant and environmental changes to the NiFi flows modified in this PR:'
+              cat "${out}/body.md"
+            else
+              echo 'No significant NiFi flow changes detected.'
+            fi
+          } > "${out}/comment.full.md"
+
+          # Keep the comment under GitHub's 65536-character limit; on overflow, truncate at a line
+          # boundary and point to the full report artifact.
+          limit=60000
+          if [ "$(wc -c < "${out}/comment.full.md")" -gt "${limit}" ]; then
+            head -c "${limit}" "${out}/comment.full.md" | sed '$ d' > "${out}/comment.md"
+            {
+              echo
+              echo '---'
+              echo "_Report truncated to fit GitHub's comment size limit. See the full \`flow-diff-report\` artifact on this workflow run._"
+            } >> "${out}/comment.md"
+          else
+            cp "${out}/comment.full.md" "${out}/comment.md"
+          fi
+
+          echo "${reportable}" > "${out}/reportable"
+
+      - name: Upload flow diff report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: flow-diff-report
+          path: flow-diff-out
+          retention-days: 5
+
+  publish:
+    name: Publish sticky comment
+    needs: [compute]
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor_id != '49699333'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # No checkout: this job holds a write token and must never execute PR-head code.
+      - name: Download flow diff report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: flow-diff-report
+          path: flow-diff-out
+
+      - name: Upsert sticky comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- nifi-flow-diff -->';
+            // github-actions[bot] stable numeric user id; identity is checked by id, not login.
+            const BOT_ID = 41898282;
+
+            const body = fs.readFileSync('flow-diff-out/comment.md', 'utf8');
+            const reportable = fs.readFileSync('flow-diff-out/reportable', 'utf8').trim() === 'true';
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Paginate: a single default page (30) can miss an older marker and cause a duplicate.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const mine = comments.filter(
+              (c) => c.user && c.user.id === BOT_ID && c.body && c.body.includes(marker)
+            );
+
+            if (mine.length > 0) {
+              // Update the canonical (oldest) comment; retire any duplicate markers.
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine[0].id, body });
+              for (const dup of mine.slice(1)) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: dup.id });
+              }
+              core.info(`Updated sticky comment ${mine[0].id}; retired ${mine.length - 1} duplicate(s).`);
+            } else if (reportable) {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Created sticky comment.');
+            } else {
+              // Nothing significant and no prior comment: post the no-change note only as a
+              // replacement, so a workflow-only or first-push technical-only PR stays silent.
+              core.info('No reportable changes and no existing comment; nothing to post.');
+            }


### PR DESCRIPTION
Adds new workflow that publishes sticky comment with NiFi flow diffs in markdown format, if any flows were modified in PR.

Closes #272.