### PR TITLE
docs: update branch parameter description in flow-diff-tool

### DIFF
--- a/qubership-nifi-tools/qubership-nifi-flow-diff-tool/README.md
+++ b/qubership-nifi-tools/qubership-nifi-flow-diff-tool/README.md
@@ -102,8 +102,10 @@ mvn -q nifi-flow-diff:<version>:diff \
 
 ### git-diff
 
-Compares the working tree against a committed baseline read through JGit. With `branch` set, the baseline is the tip of
-that branch rather than `HEAD`. The tip is deliberate: NiFi flows are replaced, not merged, so the report answers what a
+Compares the working tree against a committed baseline read through JGit. The `branch` parameter names the baseline
+revision and defaults to `HEAD`. JGit resolves it, so it accepts any of: `HEAD`, a complete or abbreviated SHA-1, a
+complete reference name (`refs/...`), or a short name under `refs/heads`, `refs/tags`, or `refs/remotes`. For a branch,
+the baseline is its tip, not the merge-base: NiFi flows are replaced, not merged, so the report answers what a
 replacement would introduce.
 
 ```shell
@@ -135,7 +137,7 @@ The table below describes the plugin parameters:
 | `baseline`       | `baseline`         | diff                           | -       | Required. Baseline directory or single flow file.                              |
 | `target`         | `target`           | diff                           | -       | Required. Target directory or single flow file.                                |
 | `path`           | `path`             | git-diff, git-revert-technical | -       | Required. Directory or single flow file, relative to the Maven `basedir`.      |
-| `branch`         | `branch`           | git-diff                       | `HEAD`  | Branch whose tip is the baseline.                                              |
+| `branch`         | `branch`           | git-diff                       | `HEAD`  | Baseline revision resolved by JGit (see the git-diff section for forms).       |
 | `format`         | `format`           | diff, git-diff                 | `text`  | Report format: `text`, `json`, or `md`.                                        |
 | `output`         | `output`           | diff, git-diff                 | -       | Report file. Required for `json` and `md`; `text` defaults to standard output. |
 | `maxValueLength` | `max-value-length` | diff, git-diff                 | `200`   | Value truncation budget for `text` and `md`; `0` disables truncation.          |

--- a/qubership-nifi-tools/qubership-nifi-flow-diff-tool/src/main/java/org/qubership/nifi/maven/flowdiff/io/GitSource.java
+++ b/qubership-nifi-tools/qubership-nifi-flow-diff-tool/src/main/java/org/qubership/nifi/maven/flowdiff/io/GitSource.java
@@ -146,12 +146,13 @@ public final class GitSource implements Closeable {
     }
 
     /**
-     * Discovers the committed flow candidates at the tip of a branch (or {@code HEAD}) under the input path, recording
+     * Discovers the committed flow candidates at the resolved baseline commit under the input path, recording
      * each blob's {@code ObjectId} without reading it, keyed by worktree-relative path. Each candidate opens and
      * classifies its blob only when loaded, so the repository must stay open (this source not yet closed) until the
      * candidates are loaded.
      *
-     * @param branch the branch name or {@code HEAD} whose tip is the baseline
+     * @param branch the baseline revision, resolved by JGit: {@code HEAD}, a complete or abbreviated SHA-1, a
+     *               complete reference name ({@code refs/...}), or a short branch, tag, or remote name
      * @return the committed candidates keyed by worktree-relative path
      * @throws IOException when a tree cannot be walked
      */

--- a/qubership-nifi-tools/qubership-nifi-flow-diff-tool/src/main/java/org/qubership/nifi/maven/flowdiff/mojo/GitDiffMojo.java
+++ b/qubership-nifi-tools/qubership-nifi-flow-diff-tool/src/main/java/org/qubership/nifi/maven/flowdiff/mojo/GitDiffMojo.java
@@ -18,8 +18,9 @@ import java.util.Map;
 
 /**
  * The {@code nifi-flow-diff:git-diff} goal: compares the working tree against a committed baseline read through JGit.
- * The baseline is the tip of {@code HEAD} or of {@code branch}; the target is the working copy. Comparing against the
- * branch tip (not the merge-base) answers what a replace would introduce, matching how NiFi flows are integrated.
+ * The baseline is the commit that {@code branch} resolves to (defaulting to {@code HEAD}); the target is the working
+ * copy. For a branch, the baseline is its tip, not the merge-base, which answers what a replace would introduce,
+ * matching how NiFi flows are integrated.
  */
 @Mojo(name = "git-diff", defaultPhase = LifecyclePhase.NONE, requiresProject = false, threadSafe = true)
 public final class GitDiffMojo extends AbstractFlowDiffMojo {
@@ -31,7 +32,10 @@ public final class GitDiffMojo extends AbstractFlowDiffMojo {
     @Parameter(property = "path", required = true)
     private String path;
 
-    /** The branch whose tip is the baseline; defaults to {@code HEAD}. */
+    /**
+     * The baseline revision, resolved by JGit: {@code HEAD}, a complete or abbreviated SHA-1, a complete reference
+     * name ({@code refs/...}), or a short branch, tag, or remote name. Defaults to {@code HEAD}.
+     */
     @Parameter(property = "branch", defaultValue = "HEAD")
     private String branch;
 


### PR DESCRIPTION
branch parameter description should describe all accepted values (branch name, HEAD, SHA, tag names, etc).