### PR TITLE
chore: upgrade upload-artifact to 7.0.1

### DIFF
--- a/.github/workflows/dev-tools-test.yml
+++ b/.github/workflows/dev-tools-test.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload test results and logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dev-tools-it-${{ matrix.nifi.tag }}-results
           path: |

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -158,7 +158,7 @@ jobs:
           fi
       - name: Upload test results
         if: failure() || cancelled()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nifi-autotests-${{ matrix.run-mode }}-logs
           path: |

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload test results
         if: failure() || cancelled()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-unit-test-logs
           path: |
@@ -169,7 +169,7 @@ jobs:
           retention-days: 2
       - name: Upload all Maven target directories
         if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-id }}
           path: '**/target'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-test-results
           path: pytest-results.xml

--- a/.github/workflows/upgrade-advisor-test.yml
+++ b/.github/workflows/upgrade-advisor-test.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: upgrade-advisor-test-results
           path: dev-tools-integration-tests/target/failsafe-reports/


### PR DESCRIPTION
Upgrades upload-artifact action in github workflows/actions to 7.0.1.